### PR TITLE
Trust Wallet browser extension

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @reef-knot/connect-wallet-modal
+
+## 0.1.0
+
+### Minor Changes
+
+- Support Trust Wallet browser extension
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/web3-react@0.1.0

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback } from 'react';
 import { useConnectorBraveWallet, helpers } from '@reef-knot/web3-react';
-import { Brave } from '@lidofinance/lido-ui';
+import { Brave as WalletIcon } from '@lidofinance/lido-ui';
 import { CONFLICTS } from '../constants/conflictChecks';
 import { ConnectWalletProps } from './types';
 import ConnectButton from './connectButton';
@@ -13,7 +13,6 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
   const { onConnect, shouldInvertWalletIcon, setRequirements, ...rest } = props;
   const { isBraveWalletProvider, isMetamaskProvider } = helpers;
   const { connect } = useConnectorBraveWallet();
-  const WalletIcon = Brave;
 
   const handleConflicts = useCallback(async () => {
     // Since the Brave Wallet is built into the Brave Browser and available only there,
@@ -26,6 +25,7 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
         CONFLICTS.Exodus,
         CONFLICTS.Gamestop,
         CONFLICTS.Xdefi,
+        CONFLICTS.Trust,
       ]);
 
       // If no other conflicts were found, then also check for a conflict with MetaMask
@@ -59,7 +59,7 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
       }
     }
     return false;
-  }, [WalletIcon, isBraveWalletProvider, isMetamaskProvider, setRequirements]);
+  }, [isBraveWalletProvider, isMetamaskProvider, setRequirements]);
 
   const handleConnect = useCallback(async () => {
     const hasConflicts = await handleConflicts();

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
@@ -18,6 +18,7 @@ const ConnectCoin98: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
         CONFLICTS.Exodus,
         CONFLICTS.Gamestop,
         CONFLICTS.Xdefi,
+        CONFLICTS.Trust,
       ]);
 
     if (hasConflicts) {

--- a/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
@@ -33,6 +33,7 @@ const ConnectGamestop: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
         CONFLICTS.Exodus,
         CONFLICTS.Coinbase,
         CONFLICTS.Xdefi,
+        CONFLICTS.Trust,
       ]);
 
     if (hasConflicts) {

--- a/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
@@ -1,11 +1,11 @@
 import { FC, useCallback } from 'react';
-import { ConnectWalletProps } from './types';
-import ConnectButton from './connectButton';
 import {
   MathWalletCircle,
   MathWalletCircleInversion,
 } from '@lidofinance/lido-ui';
 import { useConnectorMathWallet } from '@reef-knot/web3-react';
+import { ConnectWalletProps } from './types';
+import ConnectButton from './connectButton';
 import { CONFLICTS } from '../constants/conflictChecks';
 import checkConflicts from './checkConflicts';
 
@@ -25,6 +25,7 @@ const ConnectMathWallet: FC<ConnectWalletProps> = (
         CONFLICTS.Gamestop,
         CONFLICTS.Tally,
         CONFLICTS.Exodus,
+        CONFLICTS.Trust,
       ]);
 
     if (hasConflicts) {

--- a/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
@@ -22,6 +22,7 @@ const ConnectMetamask: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
         CONFLICTS.Coin98,
         CONFLICTS.MathWallet,
         CONFLICTS.Tally,
+        CONFLICTS.Trust,
       ]);
 
     if (hasConflicts) {

--- a/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback } from 'react';
 import { useConnectorOperaWallet } from '@reef-knot/web3-react';
-import { OperaWallet } from '@lidofinance/lido-ui';
+import { OperaWallet as WalletIcon } from '@lidofinance/lido-ui';
 import { ConnectWalletProps } from './types';
 import ConnectButton from './connectButton';
 
@@ -9,7 +9,6 @@ const ConnectOperaWallet: FC<ConnectWalletProps> = (
 ) => {
   const { onConnect, shouldInvertWalletIcon, setRequirements, ...rest } = props;
   const { connect } = useConnectorOperaWallet();
-  const WalletIcon = OperaWallet;
 
   // As of August 2022, Opera Crypto Browser has very few wallets in their extensions store.
   // It allows to install wallets from Chrome extensions store, but doesn't allow them to modify `window.ethereum`.

--- a/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
@@ -1,6 +1,6 @@
 import { FC, useCallback } from 'react';
 import { useConnectorXdefi } from '@reef-knot/web3-react';
-import { XdefiWallet } from '@lidofinance/lido-ui';
+import { XdefiWallet as WalletIcon } from '@lidofinance/lido-ui';
 import { CONFLICTS } from '../constants/conflictChecks';
 import { ConnectWalletProps } from './types';
 import ConnectButton from './connectButton';
@@ -9,11 +9,10 @@ import checkConflicts from './checkConflicts';
 const ConnectXdefi: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   const { onConnect, setRequirements, ...rest } = props;
   const { connect } = useConnectorXdefi();
-  const WalletIcon = XdefiWallet;
 
   const handleConnect = useCallback(async () => {
     const { hasConflicts, conflictingApps, conflictingAppsArray } =
-      checkConflicts([CONFLICTS.Exodus, CONFLICTS.Tally]);
+      checkConflicts([CONFLICTS.Exodus, CONFLICTS.Tally, CONFLICTS.Trust]);
 
     if (hasConflicts) {
       setRequirements(true, {
@@ -36,7 +35,7 @@ const ConnectXdefi: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
 
     onConnect?.();
     await connect();
-  }, [onConnect, connect, setRequirements, WalletIcon]);
+  }, [onConnect, connect, setRequirements]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/constants/conflictChecks.ts
+++ b/packages/connect-wallet-modal/src/constants/conflictChecks.ts
@@ -10,6 +10,7 @@ export type ConflictChecks = {
   Gamestop: ConflictCheck;
   Coinbase: ConflictCheck;
   Xdefi: ConflictCheck;
+  Trust: ConflictCheck;
 };
 
 export const CONFLICTS: ConflictChecks = {
@@ -20,4 +21,5 @@ export const CONFLICTS: ConflictChecks = {
   Gamestop: [helpers.isGamestopProvider, 'GameStop'],
   Coinbase: [helpers.isCoinbaseProvider, 'Coinbase'],
   Xdefi: [helpers.isXdefiProvider, 'XDEFI'],
+  Trust: [helpers.isTrustProvider, 'Trust'],
 };

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,0 +1,13 @@
+# reef-knot
+
+## 0.1.0
+
+### Minor Changes
+
+- Support Trust Wallet browser extension
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.0.0
+  - @reef-knot/web3-react@0.1.0

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @reef-knot/web3-react
+
+## 0.1.0
+
+### Minor Changes
+
+- Support Trust Wallet browser extension

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/web3-react/src/hooks/useConnectorTrust.ts
+++ b/packages/web3-react/src/hooks/useConnectorTrust.ts
@@ -13,7 +13,8 @@ type ConnectorHookResult = {
   connector: InjectedConnector;
 };
 
-const WALLET_URL_MOBILE = 'https://link.trustwallet.com/open_url?url=';
+const WALLET_URL_MOBILE =
+  'https://link.trustwallet.com/open_url?coin_id=60&url=';
 const WALLET_URL_BROWSER = 'https://trustwallet.com/browser-extension';
 
 export const useConnectorTrust = (): ConnectorHookResult => {

--- a/packages/web3-react/src/hooks/useConnectorTrust.ts
+++ b/packages/web3-react/src/hooks/useConnectorTrust.ts
@@ -5,7 +5,7 @@ import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isTrustProvider } from '../helpers';
+import { hasInjected, isTrustProvider, isMobileOrTablet } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 
 type ConnectorHookResult = {
@@ -13,7 +13,8 @@ type ConnectorHookResult = {
   connector: InjectedConnector;
 };
 
-const WALLET_URL = 'https://link.trustwallet.com/open_url?url=';
+const WALLET_URL_MOBILE = 'https://link.trustwallet.com/open_url?url=';
+const WALLET_URL_BROWSER = 'https://trustwallet.com/browser-extension';
 
 export const useConnectorTrust = (): ConnectorHookResult => {
   const { injected } = useConnectors();
@@ -22,8 +23,12 @@ export const useConnectorTrust = (): ConnectorHookResult => {
 
   const openInWallet = useCallback(() => {
     try {
-      const pageUrl = encodeURIComponent(window.location.href);
-      openWindow(`${WALLET_URL}${pageUrl}`);
+      if (isMobileOrTablet) {
+        const pageUrl = encodeURIComponent(window.location.href);
+        openWindow(`${WALLET_URL_MOBILE}${pageUrl}`);
+      } else {
+        openWindow(WALLET_URL_BROWSER);
+      }
     } catch (error) {
       warning(false, 'Failed to open the link');
     }


### PR DESCRIPTION
This PR:
- allows users to connect via Trust Wallet browser extension
- handles wallets conflicts related to the Trust Wallet extension
- bumps to v0.1.0

Related:
- https://trustwallet.com/browser-extension
- https://developer.trustwallet.com/trust-wallet-browser-extension/extension-guide