### PR TITLE
Fix: Ledger direct connection error description

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 0.1.1
+
+### Patch Changes
+
+- Add explanation for Ledger direct connection error
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
@@ -16,6 +16,7 @@ const ConnectLedger: FC<ConnectWalletProps> = (props) => {
       setRequirements(true, {
         icon: <WalletIcon />,
         title: "Ledger couldn't connect",
+        text: "Your browser doesn't support direct connection with Ledger. Please, try another browser.",
       });
       return;
     }

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 0.1.1
+
+### Patch Changes
+
+- Add explanation for Ledger direct connection error
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@0.1.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
- Add explanation for Ledger direct connection error (reproducible on Firefox, for example)

<img width="447" alt="image" src="https://user-images.githubusercontent.com/1245209/201921990-24d31bd5-01fc-4ffe-b631-1b89e03c3fa5.png">

- Bumps to v0.1.1