### PR TITLE
Fix sub-packages versions in reef-knot's dependencies

### DIFF
--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "@lido-sdk/constants": ">=1.6",
     "@lido-sdk/react": ">=1.18",
-    "@reef-knot/web3-react": "*",
+    "@reef-knot/web3-react": ">=0.1.0",
     "@lidofinance/lido-ui": ">=2.9",
     "react": ">=16",
     "react-dom": ">=16",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@lido-sdk/constants": "^1.6.0",
     "@lido-sdk/react": "^1.18.1",
-    "@reef-knot/web3-react": "*",
+    "@reef-knot/web3-react": "^0.1.0",
     "@lidofinance/lido-ui": "^2.16.1",
     "@storybook/react": "6.3.7",
     "@types/react": "17.0.19",

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@lido-sdk/constants": "^1.6.0",
     "@lido-sdk/react": "^1.18.1",
-    "@reef-knot/web3-react": "^0.1.0",
+    "@reef-knot/web3-react": "*",
     "@lidofinance/lido-ui": "^2.16.1",
     "@storybook/react": "6.3.7",
     "@types/react": "17.0.19",

--- a/packages/reef-knot/.npmignore
+++ b/packages/reef-knot/.npmignore
@@ -1,0 +1,4 @@
+tsconfig.json
+rollup.config.js
+src
+.turbo

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # reef-knot
 
+## 0.1.2
+
+### Patch Changes
+
+- Fix subpackages versions in dependencies
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
@@ -13,7 +13,7 @@
     "dev": "rollup -c -w"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "*",
-    "@reef-knot/web3-react": "*"
+    "@reef-knot/connect-wallet-modal": "0.1.1",
+    "@reef-knot/web3-react": "0.1.0"
   }
 }


### PR DESCRIPTION
Fixes:
- `reef-knot` index package v0.1.1 doesn't require latest sub-packages
- `reef-knot` package contains unwanted files in it because there wasn't `.npmignore`