### PR TITLE
Add Metrics wallets connection buttons "click" events

### DIFF
--- a/apps/demo-react/util/metrics.ts
+++ b/apps/demo-react/util/metrics.ts
@@ -7,6 +7,57 @@ const metrics: Metrics = {
         onClickTermsAccept: () => {
           console.log('metrics: Terms clicked');
         },
+        onClickAmbire: () => {
+          console.log('metrics: Ambire clicked');
+        },
+        onClickBlockchaincom: () => {
+          console.log('metrics: Blockchain.com clicked');
+        },
+        onClickBrave: () => {
+          console.log('metrics: Brave clicked');
+        },
+        onClickCoin98: () => {
+          console.log('metrics: Coin98 clicked');
+        },
+        onClickCoinbase: () => {
+          console.log('metrics: Coinbase clicked');
+        },
+        onClickExodus: () => {
+          console.log('metrics: Exodus clicked');
+        },
+        onClickGamestop: () => {
+          console.log('metrics: Gamestop clicked');
+        },
+        onClickImToken: () => {
+          console.log('metrics: imToken clicked');
+        },
+        onClickLedger: () => {
+          console.log('metrics: Ledger clicked');
+        },
+        onClickMathWallet: () => {
+          console.log('metrics: MathWallet clicked');
+        },
+        onClickMetamask: () => {
+          console.log('metrics: MetaMask clicked');
+        },
+        onClickOperaWallet: () => {
+          console.log('metrics: Opera Wallet clicked');
+        },
+        onClickTally: () => {
+          console.log('metrics: Tally Wallet clicked');
+        },
+        onClickTrust: () => {
+          console.log('metrics: Trust Wallet clicked');
+        },
+        onClickWC: () => {
+          console.log('metrics: WalletConnect clicked');
+        },
+        onClickXdefi: () => {
+          console.log('metrics: XDEFI clicked');
+        },
+        onClickZenGo: () => {
+          console.log('metrics: ZenGo clicked');
+        },
       },
     },
     connect: {

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 0.3.0
+
+### Minor Changes
+
+- Add Metrics Events for clicks on wallets connection buttons
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/connect-wallet-modal/src/connectButtons/connectAmbire.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectAmbire.tsx
@@ -25,6 +25,7 @@ const ConnectAmbire: FC<ConnectWalletProps> = (props) => {
     ...rest
   } = props;
   const onConnectAmbire = metrics?.events?.connect?.handlers.onConnectAmbire;
+  const onClickAmbire = metrics?.events?.click?.handlers.onClickAmbire;
   const { connect, connector } = useConnectorWalletConnectUri({
     onConnect: () => {
       onConnect?.();
@@ -42,13 +43,14 @@ const ConnectAmbire: FC<ConnectWalletProps> = (props) => {
 
   const handleConnect = useCallback(async () => {
     onBeforeConnect?.();
+    onClickAmbire?.();
 
     // because of popup blockers, window.open must be called directly from onclick handler
     newWindow = window.open('', '_blank');
     newWindow?.document.write(newWindowHtml);
 
     await connect();
-  }, [onBeforeConnect, connect]);
+  }, [onBeforeConnect, onClickAmbire, connect]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectBlockchaincom.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBlockchaincom.tsx
@@ -5,9 +5,17 @@ import { ConnectWalletProps } from './types';
 import ConnectButton from './connectButton';
 
 const ConnectBlockchaincom: FC<ConnectWalletProps> = (props) => {
-  const { onConnect, shouldInvertWalletIcon, metrics, ...rest } = props;
+  const {
+    onConnect,
+    onBeforeConnect,
+    shouldInvertWalletIcon,
+    metrics,
+    ...rest
+  } = props;
   const onConnectBlockchaincom =
     metrics?.events?.connect?.handlers.onConnectBlockchaincom;
+  const onClickBlockchaincom =
+    metrics?.events?.click?.handlers.onClickBlockchaincom;
   const { connect } = useConnectorWalletConnectNoLinks({
     onConnect: () => {
       onConnect?.();
@@ -19,8 +27,11 @@ const ConnectBlockchaincom: FC<ConnectWalletProps> = (props) => {
     : Blochainwallet;
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickBlockchaincom?.();
+
     await connect();
-  }, [connect]);
+  }, [connect, onBeforeConnect, onClickBlockchaincom]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
@@ -12,6 +12,7 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
 ) => {
   const {
     onConnect,
+    onBeforeConnect,
     shouldInvertWalletIcon,
     setRequirements,
     metrics,
@@ -19,6 +20,7 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
   } = props;
   const { isBraveWalletProvider, isMetamaskProvider } = helpers;
   const onConnectBrave = metrics?.events?.connect?.handlers.onConnectBrave;
+  const onClickBrave = metrics?.events?.click?.handlers.onClickBrave;
   const { connect } = useConnectorBraveWallet({
     onConnect: () => {
       onConnect?.();
@@ -74,11 +76,14 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
   }, [isBraveWalletProvider, isMetamaskProvider, setRequirements]);
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickBrave?.();
+
     const hasConflicts = await handleConflicts();
     if (hasConflicts) return;
 
     await connect();
-  }, [handleConflicts, connect]);
+  }, [onBeforeConnect, onClickBrave, handleConflicts, connect]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
@@ -7,8 +7,10 @@ import ConnectButton from './connectButton';
 import checkConflicts from './checkConflicts';
 
 const ConnectCoin98: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
-  const { onConnect, setRequirements, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, setRequirements, metrics, ...rest } =
+    props;
   const onConnectCoin98 = metrics?.events?.connect?.handlers.onConnectCoin98;
+  const onClickCoin98 = metrics?.events?.click?.handlers.onClickCoin98;
 
   const { connect } = useConnectorCoin98({
     onConnect: () => {
@@ -18,6 +20,9 @@ const ConnectCoin98: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   });
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickCoin98?.();
+
     const { hasConflicts, conflictingApps, conflictingAppsArray } =
       checkConflicts([
         CONFLICTS.MathWallet,
@@ -48,7 +53,7 @@ const ConnectCoin98: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     }
 
     await connect();
-  }, [connect, setRequirements]);
+  }, [connect, onBeforeConnect, onClickCoin98, setRequirements]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoinbase.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoinbase.tsx
@@ -8,6 +8,7 @@ const ConnectCoinbase: FC<ConnectWalletProps> = (props) => {
   const { onConnect, onBeforeConnect, metrics, ...rest } = props;
   const onConnectCoinbase =
     metrics?.events?.connect?.handlers.onConnectCoinbase;
+  const onClickCoinbase = metrics?.events?.click?.handlers.onClickCoinbase;
   const { connect } = useConnectorCoinbase({
     onConnect: () => {
       onConnect?.();
@@ -17,8 +18,10 @@ const ConnectCoinbase: FC<ConnectWalletProps> = (props) => {
 
   const handleConnect = useCallback(async () => {
     onBeforeConnect?.();
+    onClickCoinbase?.();
+
     await connect();
-  }, [connect, onBeforeConnect]);
+  }, [connect, onBeforeConnect, onClickCoinbase]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectExodus.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectExodus.tsx
@@ -7,8 +7,10 @@ import ConnectButton from './connectButton';
 import checkConflicts from './checkConflicts';
 
 const ConnectExodus: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
-  const { onConnect, setRequirements, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, setRequirements, metrics, ...rest } =
+    props;
   const onConnectExodus = metrics?.events?.connect?.handlers.onConnectExodus;
+  const onClickExodus = metrics?.events?.click?.handlers.onClickExodus;
   const { connect } = useConnectorExodus({
     onConnect: () => {
       onConnect?.();
@@ -67,6 +69,9 @@ const ConnectExodus: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   }, [setRequirements]);
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickExodus?.();
+
     const calledOnMobile = await handleMobile();
     if (calledOnMobile) return;
 
@@ -74,7 +79,7 @@ const ConnectExodus: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     if (hasConflicts) return;
 
     await connect();
-  }, [connect, handleConflicts, handleMobile]);
+  }, [connect, handleConflicts, handleMobile, onBeforeConnect, onClickExodus]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
@@ -7,9 +7,11 @@ import ConnectButton from './connectButton';
 import checkConflicts from './checkConflicts';
 
 const ConnectGamestop: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
-  const { onConnect, setRequirements, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, setRequirements, metrics, ...rest } =
+    props;
   const onConnectGamestop =
     metrics?.events?.connect?.handlers.onConnectGamestop;
+  const onClickGamestop = metrics?.events?.click?.handlers.onClickGamestop;
   const { connect } = useConnectorGamestop({
     onConnect: () => {
       onConnect?.();
@@ -65,6 +67,9 @@ const ConnectGamestop: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   }, [setRequirements]);
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickGamestop?.();
+
     const isNonDefault = handleNonDefaultSetting();
     if (isNonDefault) return;
 
@@ -72,7 +77,13 @@ const ConnectGamestop: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     if (hasConflicts) return;
 
     await connect();
-  }, [connect, handleConflicts, handleNonDefaultSetting]);
+  }, [
+    connect,
+    handleConflicts,
+    handleNonDefaultSetting,
+    onBeforeConnect,
+    onClickGamestop,
+  ]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectImToken.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectImToken.tsx
@@ -6,8 +6,10 @@ import ConnectButton from './connectButton';
 import { isIOS, isAndroid } from '../helpers';
 
 const ConnectImToken: FC<ConnectWalletProps> = (props) => {
-  const { onConnect, setRequirements, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, setRequirements, metrics, ...rest } =
+    props;
   const onConnectImToken = metrics?.events?.connect?.handlers.onConnectImToken;
+  const onClickImToken = metrics?.events?.click?.handlers.onClickImToken;
   const { connect } = useConnectorImToken({
     onConnect: () => {
       onConnect?.();
@@ -16,6 +18,9 @@ const ConnectImToken: FC<ConnectWalletProps> = (props) => {
   });
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickImToken?.();
+
     if (!connect || !(isIOS || isAndroid)) {
       setRequirements(true, {
         icon: <ImtokenCircle />,
@@ -25,7 +30,7 @@ const ConnectImToken: FC<ConnectWalletProps> = (props) => {
       return;
     }
     await connect();
-  }, [connect, setRequirements]);
+  }, [onBeforeConnect, onClickImToken, connect, setRequirements]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
@@ -7,12 +7,14 @@ import ConnectButton from './connectButton';
 const ConnectLedger: FC<ConnectWalletProps> = (props) => {
   const {
     onConnect,
+    onBeforeConnect,
     setRequirements,
     shouldInvertWalletIcon,
     metrics,
     ...rest
   } = props;
   const onConnectLedger = metrics?.events?.connect?.handlers.onConnectLedger;
+  const onClickLedger = metrics?.events?.click?.handlers.onClickLedger;
   const { connect, connector } = useConnectorLedger({
     onConnect: () => {
       onConnect?.();
@@ -24,6 +26,9 @@ const ConnectLedger: FC<ConnectWalletProps> = (props) => {
     : LedgerCircle;
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickLedger?.();
+
     if (!connect || !connector?.isSupported()) {
       setRequirements(true, {
         icon: <WalletIcon />,
@@ -33,7 +38,14 @@ const ConnectLedger: FC<ConnectWalletProps> = (props) => {
       return;
     }
     await connect();
-  }, [connect, connector, setRequirements, WalletIcon]);
+  }, [
+    onBeforeConnect,
+    onClickLedger,
+    connect,
+    connector,
+    setRequirements,
+    WalletIcon,
+  ]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
@@ -14,6 +14,7 @@ const ConnectMathWallet: FC<ConnectWalletProps> = (
 ) => {
   const {
     onConnect,
+    onBeforeConnect,
     shouldInvertWalletIcon,
     setRequirements,
     metrics,
@@ -21,6 +22,7 @@ const ConnectMathWallet: FC<ConnectWalletProps> = (
   } = props;
   const onConnectMathWallet =
     metrics?.events?.connect?.handlers.onConnectMathWallet;
+  const onClickMathWallet = metrics?.events?.click?.handlers.onClickMathWallet;
   const { connect } = useConnectorMathWallet({
     onConnect: () => {
       onConnect?.();
@@ -32,6 +34,9 @@ const ConnectMathWallet: FC<ConnectWalletProps> = (
     : MathWalletCircle;
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickMathWallet?.();
+
     const { hasConflicts, conflictingApps, conflictingAppsArray } =
       checkConflicts([
         CONFLICTS.Xdefi,
@@ -61,7 +66,13 @@ const ConnectMathWallet: FC<ConnectWalletProps> = (
     }
 
     await connect();
-  }, [connect, setRequirements, WalletIcon]);
+  }, [
+    onBeforeConnect,
+    onClickMathWallet,
+    connect,
+    setRequirements,
+    WalletIcon,
+  ]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
@@ -9,6 +9,7 @@ import checkConflicts from './checkConflicts';
 const ConnectMetamask: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   const {
     onConnect,
+    onBeforeConnect,
     shouldInvertWalletIcon,
     setRequirements,
     metrics,
@@ -16,6 +17,7 @@ const ConnectMetamask: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   } = props;
   const onConnectMetamask =
     metrics?.events?.connect?.handlers.onConnectMetamask;
+  const onClickMetamask = metrics?.events?.click?.handlers.onClickMetamask;
   const { connect } = useConnectorMetamask({
     onConnect: () => {
       onConnect?.();
@@ -27,6 +29,9 @@ const ConnectMetamask: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     : MetaMaskCircle;
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickMetamask?.();
+
     const { hasConflicts, conflictingApps, conflictingAppsArray } =
       checkConflicts([
         CONFLICTS.Xdefi,
@@ -58,7 +63,7 @@ const ConnectMetamask: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     }
 
     await connect();
-  }, [connect, setRequirements, WalletIcon]);
+  }, [connect, onBeforeConnect, onClickMetamask, setRequirements, WalletIcon]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
@@ -9,6 +9,7 @@ const ConnectOperaWallet: FC<ConnectWalletProps> = (
 ) => {
   const {
     onConnect,
+    onBeforeConnect,
     shouldInvertWalletIcon,
     setRequirements,
     metrics,
@@ -16,6 +17,8 @@ const ConnectOperaWallet: FC<ConnectWalletProps> = (
   } = props;
   const onConnectOperaWallet =
     metrics?.events?.connect?.handlers.onConnectOperaWallet;
+  const onClickOperaWallet =
+    metrics?.events?.click?.handlers.onClickOperaWallet;
   const { connect } = useConnectorOperaWallet({
     onConnect: () => {
       onConnect?.();
@@ -27,8 +30,11 @@ const ConnectOperaWallet: FC<ConnectWalletProps> = (
   // It allows to install wallets from Chrome extensions store, but doesn't allow them to modify `window.ethereum`.
   // Looks like no need to handle wallets conflicts right now.
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickOperaWallet?.();
+
     await connect();
-  }, [connect]);
+  }, [onBeforeConnect, onClickOperaWallet, connect]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectTally.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectTally.tsx
@@ -8,12 +8,14 @@ import { isMobileOrTablet } from '../helpers';
 const ConnectTally: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   const {
     onConnect,
+    onBeforeConnect,
     shouldInvertWalletIcon,
     setRequirements,
     metrics,
     ...rest
   } = props;
   const onConnectTally = metrics?.events?.connect?.handlers.onConnectTally;
+  const onClickTally = metrics?.events?.click?.handlers.onClickTally;
   const { connect } = useConnectorTally({
     onConnect: () => {
       onConnect?.();
@@ -22,6 +24,9 @@ const ConnectTally: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   });
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickTally?.();
+
     if (!connect || isMobileOrTablet) {
       setRequirements(true, {
         icon: <TallyCircle />,
@@ -32,7 +37,7 @@ const ConnectTally: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     }
 
     await connect();
-  }, [connect, setRequirements]);
+  }, [connect, onBeforeConnect, onClickTally, setRequirements]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectTrust.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectTrust.tsx
@@ -7,8 +7,10 @@ import checkConflicts from './checkConflicts';
 import { CONFLICTS } from '../constants/conflictChecks';
 
 const ConnectTrust: FC<ConnectWalletProps> = (props) => {
-  const { onConnect, setRequirements, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, setRequirements, metrics, ...rest } =
+    props;
   const onConnectTrust = metrics?.events?.connect?.handlers.onConnectTrust;
+  const onClickTrust = metrics?.events?.click?.handlers.onClickTrust;
   const { connect } = useConnectorTrust({
     onConnect: () => {
       onConnect?.();
@@ -17,6 +19,9 @@ const ConnectTrust: FC<ConnectWalletProps> = (props) => {
   });
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickTrust?.();
+
     const { hasConflicts, conflictingApps, conflictingAppsArray } =
       checkConflicts([CONFLICTS.Tally, CONFLICTS.Exodus]);
 
@@ -48,7 +53,7 @@ const ConnectTrust: FC<ConnectWalletProps> = (props) => {
     }
 
     await connect();
-  }, [connect, setRequirements]);
+  }, [connect, onBeforeConnect, onClickTrust, setRequirements]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectWalletConnect.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectWalletConnect.tsx
@@ -5,8 +5,9 @@ import { ConnectWalletProps } from './types';
 import ConnectButton from './connectButton';
 
 const ConnectWalletConnect: FC<ConnectWalletProps> = (props) => {
-  const { onConnect, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, metrics, ...rest } = props;
   const onConnectWC = metrics?.events?.connect?.handlers.onConnectWC;
+  const onClickWC = metrics?.events?.click?.handlers.onClickWC;
   const { connect } = useConnectorWalletConnect({
     onConnect: () => {
       onConnect?.();
@@ -15,8 +16,11 @@ const ConnectWalletConnect: FC<ConnectWalletProps> = (props) => {
   });
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickWC?.();
+
     await connect();
-  }, [connect]);
+  }, [connect, onBeforeConnect, onClickWC]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
@@ -7,8 +7,10 @@ import ConnectButton from './connectButton';
 import checkConflicts from './checkConflicts';
 
 const ConnectXdefi: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
-  const { onConnect, setRequirements, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, setRequirements, metrics, ...rest } =
+    props;
   const onConnectXdefi = metrics?.events?.connect?.handlers.onConnectXdefi;
+  const onClickXdefi = metrics?.events?.click?.handlers.onClickXdefi;
   const { connect } = useConnectorXdefi({
     onConnect: () => {
       onConnect?.();
@@ -17,6 +19,9 @@ const ConnectXdefi: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   });
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickXdefi?.();
+
     const { hasConflicts, conflictingApps, conflictingAppsArray } =
       checkConflicts([CONFLICTS.Exodus, CONFLICTS.Tally, CONFLICTS.Trust]);
 
@@ -40,9 +45,7 @@ const ConnectXdefi: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
     }
 
     await connect();
-    onConnect?.();
-    onConnectXdefi?.();
-  }, [connect, onConnect, onConnectXdefi, setRequirements]);
+  }, [connect, onBeforeConnect, onClickXdefi, setRequirements]);
 
   return (
     <ConnectButton

--- a/packages/connect-wallet-modal/src/connectButtons/connectZenGo.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectZenGo.tsx
@@ -21,8 +21,9 @@ const openDeeplink = (uri: string | undefined) => {
 };
 
 const ConnectZenGo: FC<ConnectWalletProps> = (props) => {
-  const { onConnect, metrics, ...rest } = props;
+  const { onConnect, onBeforeConnect, metrics, ...rest } = props;
   const onConnectZenGo = metrics?.events?.connect?.handlers.onConnectZenGo;
+  const onClickZenGo = metrics?.events?.click?.handlers.onClickZenGo;
   const onConnectHandler = () => {
     onConnect?.();
     onConnectZenGo?.();
@@ -45,6 +46,9 @@ const ConnectZenGo: FC<ConnectWalletProps> = (props) => {
   }, [connectorWCUri]);
 
   const handleConnect = useCallback(async () => {
+    onBeforeConnect?.();
+    onClickZenGo?.();
+
     if (isMobileOrTablet) {
       // because of popup blockers, window.open must be called directly from onclick handler
       newWindow = window.open('', '_blank');
@@ -57,7 +61,7 @@ const ConnectZenGo: FC<ConnectWalletProps> = (props) => {
     } else {
       await connect();
     }
-  }, [connectWCUri, connect]);
+  }, [onBeforeConnect, onClickZenGo, connectWCUri, connect]);
 
   return (
     <ConnectButton

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,16 @@
 # reef-knot
 
+## 0.3.0
+
+### Minor Changes
+
+- Add Metrics Events for clicks on wallets connection buttons
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@0.3.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
@@ -14,7 +14,7 @@
     "dev": "dev=on rollup -c -w"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "0.2.0",
+    "@reef-knot/connect-wallet-modal": "0.3.0",
     "@reef-knot/web3-react": "0.2.0"
   }
 }


### PR DESCRIPTION
Recently, metrics events for wallets connections were added.
This PR also adds metric events for clicking on wallets connection buttons, since there is a difference between button clicking and actually connecting.