### PR TITLE
Fix: the modal's scrollbar (gutter, dark theme)

### DIFF
--- a/apps/demo-react/components/SettingsWrapper.tsx
+++ b/apps/demo-react/components/SettingsWrapper.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+const SettingsWrapper = (props: { children: ReactNode }) => (
+  <div
+    style={{
+      alignSelf: 'flex-start',
+      display: 'flex',
+      flexDirection: 'column',
+      minWidth: '300px',
+      marginTop: '80px',
+      padding: '10px',
+      background: 'antiquewhite',
+      borderRadius: '10px',
+    }}
+  >
+    {props.children}
+  </div>
+);
+
+export default SettingsWrapper;

--- a/apps/demo-react/components/ThemeSelect.tsx
+++ b/apps/demo-react/components/ThemeSelect.tsx
@@ -1,0 +1,25 @@
+import { ThemeName } from '@lidofinance/lido-ui';
+
+const ThemeSelect = (props: {
+  selectedTheme: ThemeName;
+  handleSelect: (value: ThemeName) => void;
+}) => {
+  const { selectedTheme, handleSelect } = props;
+  return (
+    <div>
+      <label htmlFor="themeSwitcher">
+        Theme:&nbsp;
+        <select
+          name="themeSwitcher"
+          value={selectedTheme}
+          onChange={(e) => handleSelect?.(e.target.value as ThemeName)}
+        >
+          <option value={ThemeName.light}>Light</option>
+          <option value={ThemeName.dark}>Dark</option>
+        </select>
+      </label>
+    </div>
+  );
+};
+
+export default ThemeSelect;

--- a/apps/demo-react/components/WalletInfo.tsx
+++ b/apps/demo-react/components/WalletInfo.tsx
@@ -7,24 +7,13 @@ const WalletInfo = () => {
 
   return (
     <div>
-      <div
-        style={{
-          display: 'inline-block',
-          minWidth: '300px',
-          marginTop: '80px',
-          padding: '10px',
-          background: 'antiquewhite',
-          borderRadius: '10px',
-        }}
-      >
-        <h4>Info:</h4>
-        <div>
-          <code>
-            <p>providerName: {connectorInfo.providerName}</p>
-            <p>connectorName: {connectorInfo.connectorName}</p>
-            <p>account: {account}</p>
-          </code>
-        </div>
+      <h4>Info:</h4>
+      <div>
+        <code>
+          <p>providerName: {connectorInfo.providerName}</p>
+          <p>connectorName: {connectorInfo.connectorName}</p>
+          <p>account: {account}</p>
+        </code>
       </div>
     </div>
   );

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -13,7 +13,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "@lido-sdk/constants": "^1.6.0",
-    "@lidofinance/lido-ui": "3.1.0",
+    "@lidofinance/lido-ui": "3.2.0",
     "reef-knot": "*",
     "@reef-knot/ui-react": "*",
     "@reef-knot/web3-react": "*"

--- a/apps/demo-react/pages/index.tsx
+++ b/apps/demo-react/pages/index.tsx
@@ -1,6 +1,12 @@
 import dynamic from 'next/dynamic';
 import { WalletsModalForEth } from 'reef-knot';
-import { themeLight, ThemeProvider } from '@lidofinance/lido-ui';
+import {
+  themeLight,
+  themeDark,
+  ThemeProvider,
+  ThemeName,
+} from '@lidofinance/lido-ui';
+import { useState } from 'react';
 import Header from '../components/Header';
 import ProviderWeb3WithProps from '../components/ProviderWeb3WithProps';
 import WalletInfo from '../components/WalletInfo';
@@ -8,19 +14,30 @@ import useModal from '../hooks/useModal';
 import metrics from '../util/metrics';
 import MainContainer from '../components/MainContainer';
 import ConnectDisconnect from '../components/ConnectDisconnect';
+import ThemeSelect from '../components/ThemeSelect';
+import SettingsWrapper from '../components/SettingsWrapper';
 
 export function Web() {
   const { state, handleOpen, handleClose } = useModal();
+  const [selectedTheme, setSelectedTheme] = useState('light' as ThemeName);
 
   return (
     <>
       <Header />
-      <ThemeProvider theme={themeLight}>
+      <ThemeProvider
+        theme={selectedTheme === ThemeName.light ? themeLight : themeDark}
+      >
         <ProviderWeb3WithProps>
           <MainContainer>
             <ConnectDisconnect handleOpen={handleOpen} />
 
-            <WalletInfo />
+            <SettingsWrapper>
+              <ThemeSelect
+                selectedTheme={selectedTheme}
+                handleSelect={setSelectedTheme}
+              />
+              <WalletInfo />
+            </SettingsWrapper>
 
             <WalletsModalForEth
               open={state}

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @reef-knot/connect-wallet-modal
 
+## 0.5.2
+
+### Patch Changes
+
+- Fix scrollbar padding and margin
+- Support dark color theme
+- ua-parser-js 1.0.33
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/packages/connect-wallet-modal/src/components/WalletsModal/styles.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/styles.tsx
@@ -25,13 +25,13 @@ export const WalletsButtonsContainer = styled.div<{
     @supports (scrollbar-width: thin) {
       scrollbar-width: thin;
       scrollbar-color: #000a3d3d transparent;
-      padding-right: 6px;
-      margin-right: -16px;
+      padding-right: 10px;
+      margin-right: -10px;
     }
 
     @supports selector(::-webkit-scrollbar) {
-      padding-right: 10px;
-      margin-right: -10px;
+      padding-right: 6px;
+      margin-right: -16px;
 
       &::-webkit-scrollbar-track {
         margin-bottom: ${GAP_BOTTOM};

--- a/packages/connect-wallet-modal/src/components/WalletsModal/styles.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/styles.tsx
@@ -5,7 +5,7 @@ const GAP_BOTTOM = '32px';
 export const WalletsButtonsContainer = styled.div<{
   $buttonsFullWidth: boolean;
 }>`
-  ${({ $buttonsFullWidth }) => css`
+  ${({ theme, $buttonsFullWidth }) => css`
     box-sizing: content-box;
     max-height: 370px;
     display: grid;
@@ -24,9 +24,9 @@ export const WalletsButtonsContainer = styled.div<{
 
     @supports (scrollbar-width: thin) {
       scrollbar-width: thin;
-      scrollbar-color: #000a3d3d transparent;
-      padding-right: 10px;
-      margin-right: -10px;
+      scrollbar-color: ${theme.colors.border} transparent;
+      padding-right: 12px;
+      margin-right: -12px;
     }
 
     @supports selector(::-webkit-scrollbar) {
@@ -50,7 +50,7 @@ export const WalletsButtonsContainer = styled.div<{
         border-width: 2px;
         border-radius: 30px;
         background-clip: content-box;
-        background-color: #000a3d3d;
+        background-color: ${theme.colors.border};
 
         &:hover {
           border-width: 0;

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # reef-knot
 
+## 0.5.2
+
+### Patch Changes
+
+- Fix scrollbar padding and margin
+- Support dark color theme
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@0.5.2
+  - ua-parser-js@1.0.33
+
 ## 0.5.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",
@@ -17,7 +17,7 @@
     "dev": "dev=on rollup -c -w"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "0.5.1",
+    "@reef-knot/connect-wallet-modal": "0.5.2",
     "@reef-knot/web3-react": "0.3.0",
     "@reef-knot/ui-react": "0.2.0",
     "@reef-knot/wallets-icons": "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,10 +2657,10 @@
   dependencies:
     typescript "4.6"
 
-"@lidofinance/lido-ui@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ui/-/lido-ui-3.1.0.tgz#b180221356c8eb36c0882e6e5307f9a10999e3eb"
-  integrity sha512-i70O0bwDPBE35gVg1xrwsHmvTYE4Rgdmi+lqnOzT2xA1KOtaWMnUyuURLn6UxvpfppNOoXxZLZJpv1DU6qr4MA==
+"@lidofinance/lido-ui@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@lidofinance/lido-ui/-/lido-ui-3.2.0.tgz#f46f5103268e3324a48589f6ffc9edee04cb6cf7"
+  integrity sha512-tNeePz3CyxIqLrRs2n++Dt9pBcCzsdSieUTuqAe1Tan8Oe5pzNUcqSodP2i+X8ohUbelcccEI5SkyoD9tKPuHg==
   dependencies:
     "@styled-system/should-forward-prop" "5.1.5"
     "@swc/helpers" "^0.4.11"


### PR DESCRIPTION
Followup for this PR: https://github.com/lidofinance/reef-knot/pull/19
- Fixed the mixed up scrollbar's paddings and margins
- Use colors from theme to support dark color theme
- Add a simple theme select to the demo page
- The 0.5.2 version will also include this change: https://github.com/lidofinance/reef-knot/pull/20


https://user-images.githubusercontent.com/1245209/215496238-0b54f530-ff8e-4e65-a044-75086eca9124.mp4

