### PR TITLE
Release v1.0 and remove some lido-sdk deps

### DIFF
--- a/apps/demo-react/components/ProviderWeb3WithProps.tsx
+++ b/apps/demo-react/components/ProviderWeb3WithProps.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react';
-import { CHAINS } from '@lido-sdk/constants';
+import { mainnet } from 'wagmi/chains';
 import { ProviderWeb3 } from 'reef-knot/web3-react';
 import { rpc } from '../util/rpc';
 
 const ProviderWeb3WithProps = (props: { children: ReactNode }) => (
   <ProviderWeb3
-    defaultChainId={CHAINS.Mainnet}
-    supportedChainIds={[CHAINS.Mainnet]}
+    defaultChainId={mainnet.id}
+    supportedChainIds={[mainnet.id]}
     rpc={rpc}
   >
     {props.children}

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@lido-sdk/constants": "^1.6.0",
     "@lidofinance/lido-ui": "3.2.0",
     "ethers": "^5.7.2",
     "next": "12.3.4",

--- a/apps/demo-react/util/rpc.ts
+++ b/apps/demo-react/util/rpc.ts
@@ -1,6 +1,6 @@
-import { CHAINS } from '@lido-sdk/constants';
+import { mainnet, goerli } from 'wagmi/chains';
 
 export const rpc = {
-  [CHAINS.Mainnet]: `/rpc-stub?chainId=${CHAINS.Mainnet}`,
-  [CHAINS.Goerli]: `/rpc-stub?chainId=${CHAINS.Goerli}`,
+  [mainnet.id]: `/rpc-stub?chainId=${mainnet.id}`,
+  [goerli.id]: `/rpc-stub?chainId=${goerli.id}`,
 };

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.0.0
+
+### Major Changes
+
+- #### v1.0 is an update starting migration to wagmi
+  - Update TS to 4.9.5, tslib to 2.5.0, rollup to 3.15.0
+  - Update build config: generate ESM modules only, update tsconfig, change packages exports
+  - Workaround styled-components ESM issue
+  - Add wagmi dependency
+  - Use wagmi controllers for all WalletConnect wallets (WC v2 support)
+  - Add a modular wallet adapter API
+  - Use a wallet adapter API with wagmi injected controller for Exodus wallet
+  - Remove most of @lido-sdk dependencies
+  - Cleanup and other minor changes
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/web3-react@1.0.0
+  - @reef-knot/core-react@1.0.0
+  - @reef-knot/ui-react@1.0.0
+  - @reef-knot/wallets-icons@1.0.0
+  - @reef-knot/wallets-list@1.0.0
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -38,11 +38,10 @@
   },
   "devDependencies": {
     "@reef-knot/core-react": "^0.0.0",
-    "@lido-sdk/react": "^1.18.5",
     "@reef-knot/ui-react": "^0.2.0",
     "@reef-knot/wallets-icons": "^0.2.0",
-    "@reef-knot/web3-react": "^0.3.0",
     "@reef-knot/wallets-list": "^0.0.0",
+    "@reef-knot/web3-react": "^0.3.0",
     "@types/react": "17.0.53",
     "@types/ua-parser-js": "^0.7.36",
     "ethers": "^5.7.2",
@@ -52,14 +51,13 @@
   },
   "peerDependencies": {
     "@reef-knot/core-react": "^0.0.0",
-    "@lido-sdk/react": ">=1.18",
     "@reef-knot/ui-react": "^0.2.0",
     "@reef-knot/wallets-icons": "^0.2.0",
-    "@reef-knot/web3-react": "^0.3.0",
     "@reef-knot/wallets-list": "^0.0.0",
+    "@reef-knot/web3-react": "^0.3.0",
+    "@walletconnect/ethereum-provider": "^1.8.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
-    "wagmi": "^0.11.5",
-    "@walletconnect/ethereum-provider": "^1.8.0"
+    "wagmi": "^0.11.5"
   }
 }

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "0.5.2",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,11 +37,11 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/core-react": "^0.0.0",
-    "@reef-knot/ui-react": "^0.2.0",
-    "@reef-knot/wallets-icons": "^0.2.0",
-    "@reef-knot/wallets-list": "^0.0.0",
-    "@reef-knot/web3-react": "^0.3.0",
+    "@reef-knot/core-react": "^1.0.0",
+    "@reef-knot/ui-react": "^1.0.0",
+    "@reef-knot/wallets-icons": "^1.0.0",
+    "@reef-knot/wallets-list": "^1.0.0",
+    "@reef-knot/web3-react": "^1.0.0",
     "@types/react": "17.0.53",
     "@types/ua-parser-js": "^0.7.36",
     "ethers": "^5.7.2",
@@ -50,11 +50,11 @@
     "wagmi": "^0.11.5"
   },
   "peerDependencies": {
-    "@reef-knot/core-react": "^0.0.0",
-    "@reef-knot/ui-react": "^0.2.0",
-    "@reef-knot/wallets-icons": "^0.2.0",
-    "@reef-knot/wallets-list": "^0.0.0",
-    "@reef-knot/web3-react": "^0.3.0",
+    "@reef-knot/core-react": "^1.0.0",
+    "@reef-knot/ui-react": "^1.0.0",
+    "@reef-knot/wallets-icons": "^1.0.0",
+    "@reef-knot/wallets-list": "^1.0.0",
+    "@reef-knot/web3-react": "^1.0.0",
     "@walletconnect/ethereum-provider": "^1.8.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",

--- a/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react';
-import { useLocalStorage } from '@lido-sdk/react';
 import { Modal } from '@reef-knot/ui-react';
 import {
   WalletsModalProps,
@@ -8,7 +7,7 @@ import {
 } from './types';
 import { Terms } from '../Terms';
 import { WalletsButtonsContainer } from './styles';
-import { NOOP } from '../../helpers';
+import { NOOP, useLocalStorage } from '../../helpers';
 
 export function WalletsModal(props: WalletsModalProps): JSX.Element {
   const {
@@ -21,7 +20,7 @@ export function WalletsModal(props: WalletsModalProps): JSX.Element {
   } = props;
 
   const [termsChecked, setTermsChecked] = useLocalStorage(
-    'lido-terms-agree',
+    'reef-knot_terms-agree',
     false,
   );
 

--- a/packages/connect-wallet-modal/src/helpers/index.ts
+++ b/packages/connect-wallet-modal/src/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './user-agents';
 export * from './noop';
 export * from './capitalize';
+export * from './useLocalStorage';

--- a/packages/connect-wallet-modal/src/helpers/useLocalStorage.ts
+++ b/packages/connect-wallet-modal/src/helpers/useLocalStorage.ts
@@ -4,35 +4,31 @@ export function useLocalStorage(key: string, initialValue: any) {
   // State to store our value
   // Pass initial state function to useState so logic is only executed once
   const [storedValue, setStoredValue] = useState(() => {
-    if (typeof window === 'undefined') {
-      return initialValue;
-    }
-    try {
-      // Get from local storage by key
+    if (window?.localStorage?.hasItem(key)) {
       const item = window.localStorage.getItem(key);
-      // Parse stored json or if none return initialValue
-      return item ? JSON.parse(item) : initialValue;
-    } catch (error) {
-      // If error also return initialValue
-      console.log(error);
-      return initialValue;
+      try {
+        // Parse stored json or if none return initialValue
+        return item ? JSON.parse(item) : initialValue;
+      } catch (error) {
+        console.error(
+          `Reef Knot tried to parse a localStorage value using key: "${key}" and got the error:`,
+          error,
+        );
+        return initialValue;
+      }
     }
+    return initialValue;
   });
 
   // Return a wrapped version of useState's setter function that persists the new value to localStorage.
   const setValue = (value: any) => {
-    try {
-      // Allow value to be a function, so we have same API as useState
-      const valueToStore =
-        value instanceof Function ? value(storedValue) : value;
-      // Save state
-      setStoredValue(valueToStore);
-      // Save to local storage
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem(key, JSON.stringify(valueToStore));
-      }
-    } catch (error) {
-      console.log(error);
+    // Allow value to be a function, so we have same API as useState
+    const valueToStore = value instanceof Function ? value(storedValue) : value;
+    // Save state
+    setStoredValue(valueToStore);
+    // Save to local storage
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
     }
   };
   return [storedValue, setValue];

--- a/packages/connect-wallet-modal/src/helpers/useLocalStorage.ts
+++ b/packages/connect-wallet-modal/src/helpers/useLocalStorage.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+export function useLocalStorage(key: string, initialValue: any) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  // Return a wrapped version of useState's setter function that persists the new value to localStorage.
+  const setValue = (value: any) => {
+    try {
+      // Allow value to be a function, so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue];
+}

--- a/packages/connect-wallet-modal/src/helpers/useLocalStorage.ts
+++ b/packages/connect-wallet-modal/src/helpers/useLocalStorage.ts
@@ -6,16 +6,8 @@ export function useLocalStorage(key: string, initialValue: any) {
   const [storedValue, setStoredValue] = useState(() => {
     if (window?.localStorage?.hasItem(key)) {
       const item = window.localStorage.getItem(key);
-      try {
-        // Parse stored json or if none return initialValue
-        return item ? JSON.parse(item) : initialValue;
-      } catch (error) {
-        console.error(
-          `Reef Knot tried to parse a localStorage value using key: "${key}" and got the error:`,
-          error,
-        );
-        return initialValue;
-      }
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
     }
     return initialValue;
   });

--- a/packages/core-react/CHANGELOG.md
+++ b/packages/core-react/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @reef-knot/web3-react
+# @reef-knot/core-react
 
 ## 1.0.0
 
@@ -14,21 +14,3 @@
   - Use a wallet adapter API with wagmi injected controller for Exodus wallet
   - Remove most of @lido-sdk dependencies
   - Cleanup and other minor changes
-
-## 0.3.0
-
-### Minor Changes
-
-- Add Zerion wallet detection
-
-## 0.2.0
-
-### Minor Changes
-
-- Add Metrics Events support
-
-## 0.1.0
-
-### Minor Changes
-
-- Support Trust Wallet browser extension

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/core-react",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,30 @@
 # reef-knot
 
+## 1.0.0
+
+### Major Changes
+
+- #### v1.0 is an update starting migration to wagmi
+  - Update TS to 4.9.5, tslib to 2.5.0, rollup to 3.15.0
+  - Update build config: generate ESM modules only, update tsconfig, change packages exports
+  - Workaround styled-components ESM issue
+  - Add wagmi dependency
+  - Use wagmi controllers for all WalletConnect wallets (WC v2 support)
+  - Add a modular wallet adapter API
+  - Use a wallet adapter API with wagmi injected controller for Exodus wallet
+  - Remove most of @lido-sdk dependencies
+  - Cleanup and other minor changes
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.0.0
+  - @reef-knot/web3-react@1.0.0
+  - @reef-knot/core-react@1.0.0
+  - @reef-knot/ui-react@1.0.0
+  - @reef-knot/wallets-icons@1.0.0
+  - @reef-knot/wallets-list@1.0.0
+
 ## 0.5.2
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "0.5.2",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -9,8 +9,12 @@
   },
   "typesVersions": {
     "*": {
-      ".": ["dist/index.d.ts"],
-      "*": ["dist/packages/*"]
+      ".": [
+        "dist/index.d.ts"
+      ],
+      "*": [
+        "dist/packages/*"
+      ]
     }
   },
   "type": "module",
@@ -36,11 +40,11 @@
     "dev": "dev=on rollup -c -w"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "0.5.2",
-    "@reef-knot/web3-react": "0.3.0",
-    "@reef-knot/ui-react": "0.2.0",
-    "@reef-knot/wallets-icons": "0.2.0",
-    "@reef-knot/core-react": "0.0.0",
-    "@reef-knot/wallets-list": "0.0.0"
+    "@reef-knot/connect-wallet-modal": "1.0.0",
+    "@reef-knot/web3-react": "1.0.0",
+    "@reef-knot/ui-react": "1.0.0",
+    "@reef-knot/wallets-icons": "1.0.0",
+    "@reef-knot/core-react": "1.0.0",
+    "@reef-knot/wallets-list": "1.0.0"
   }
 }

--- a/packages/ui-react/CHANGELOG.md
+++ b/packages/ui-react/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @reef-knot/ui-react
 
+## 1.0.0
+
+### Major Changes
+
+- #### v1.0 is an update starting migration to wagmi
+  - Update TS to 4.9.5, tslib to 2.5.0, rollup to 3.15.0
+  - Update build config: generate ESM modules only, update tsconfig, change packages exports
+  - Workaround styled-components ESM issue
+  - Add wagmi dependency
+  - Use wagmi controllers for all WalletConnect wallets (WC v2 support)
+  - Add a modular wallet adapter API
+  - Use a wallet adapter API with wagmi injected controller for Exodus wallet
+  - Remove most of @lido-sdk dependencies
+  - Cleanup and other minor changes
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ui-react",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -9,8 +9,12 @@
   },
   "typesVersions": {
     "*": {
-      ".": ["dist/index.d.ts"],
-      "styled-wrapper": ["dist/utils/styledWrapper.d.ts"]
+      ".": [
+        "dist/index.d.ts"
+      ],
+      "styled-wrapper": [
+        "dist/utils/styledWrapper.d.ts"
+      ]
     }
   },
   "type": "module",

--- a/packages/wallets-icons/CHANGELOG.md
+++ b/packages/wallets-icons/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @reef-knot/wallets-icons
 
+## 1.0.0
+
+### Major Changes
+
+- #### v1.0 is an update starting migration to wagmi
+  - Update TS to 4.9.5, tslib to 2.5.0, rollup to 3.15.0
+  - Update build config: generate ESM modules only, update tsconfig, change packages exports
+  - Workaround styled-components ESM issue
+  - Add wagmi dependency
+  - Use wagmi controllers for all WalletConnect wallets (WC v2 support)
+  - Add a modular wallet adapter API
+  - Use a wallet adapter API with wagmi injected controller for Exodus wallet
+  - Remove most of @lido-sdk dependencies
+  - Cleanup and other minor changes
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/wallets-icons/package.json
+++ b/packages/wallets-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-icons",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -10,11 +10,15 @@
   },
   "typesVersions": {
     "*": {
-      ".": ["dist/index.d.ts"],
+      ".": [
+        "dist/index.d.ts"
+      ],
       "react": [
         "dist/react/index.d.ts"
       ],
-      "svg/*": ["dist/svg/*"]
+      "svg/*": [
+        "dist/svg/*"
+      ]
     }
   },
   "type": "module",

--- a/packages/wallets-list/CHANGELOG.md
+++ b/packages/wallets-list/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @reef-knot/web3-react
+# @reef-knot/wallets-list
 
 ## 1.0.0
 
@@ -15,20 +15,8 @@
   - Remove most of @lido-sdk dependencies
   - Cleanup and other minor changes
 
-## 0.3.0
+### Patch Changes
 
-### Minor Changes
-
-- Add Zerion wallet detection
-
-## 0.2.0
-
-### Minor Changes
-
-- Add Metrics Events support
-
-## 0.1.0
-
-### Minor Changes
-
-- Support Trust Wallet browser extension
+- Updated dependencies
+  - @reef-knot/core-react@1.0.0
+  - @reef-knot/wallet-adapter-exodus@1.0.0

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-list",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -36,13 +36,13 @@
     "dev": "dev=on rollup -c -w"
   },
   "dependencies": {
-    "@reef-knot/wallet-adapter-exodus": "0.0.0"
+    "@reef-knot/wallet-adapter-exodus": "1.0.0"
   },
   "devDependencies": {
-    "@reef-knot/core-react": "^0.0.0"
+    "@reef-knot/core-react": "^1.0.0"
   },
   "peerDependencies": {
-    "@reef-knot/core-react": "^0.0.0",
+    "@reef-knot/core-react": "^1.0.0",
     "react": ">=17"
   }
 }

--- a/packages/wallets/exodus/CHANGELOG.md
+++ b/packages/wallets/exodus/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @reef-knot/wallet-adapter-exodus
+
+## 1.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/core-react@1.0.0

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-exodus",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,10 +32,10 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/core-react": "^0.0.0",
+    "@reef-knot/core-react": "^1.0.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "@reef-knot/core-react": "^0.0.0"
+    "@reef-knot/core-react": "^1.0.0"
   }
 }

--- a/packages/wallets/exodus/src/index.ts
+++ b/packages/wallets/exodus/src/index.ts
@@ -8,8 +8,9 @@ export const Exodus: WalletAdapterType = () => ({
     light: WalletIcon,
     dark: WalletIcon,
   },
-  detector: () => true,
+  detector: () => !!window.ethereum?.isExodus,
   downloadURLs: {
-    default: '',
+    default: 'https://www.exodus.com/download/',
   },
+  // TODO: handle wallet conflicts and custom connectors
 });

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -64,7 +64,6 @@
     "@gnosis.pm/safe-apps-web3-react": "0.6.8",
     "@ledgerhq/iframe-provider": "0.4.2",
     "@lido-sdk/constants": "^1.8.1",
-    "@lido-sdk/helpers": "^1.4.7",
     "@lido-sdk/providers": "^1.4.8",
     "@lido-sdk/react": "^1.18.5",
     "@web3-react/abstract-connector": "6.0.7",

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/helpers/index.ts
+++ b/packages/web3-react/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from './providerDetectors';
 export * from './ua';
+export * from './openWindow';
 export { default as isUrl } from './isUrl';
 export { default as interceptLedgerError } from './interceptLedgerError';

--- a/packages/web3-react/src/helpers/openWindow.ts
+++ b/packages/web3-react/src/helpers/openWindow.ts
@@ -1,0 +1,5 @@
+export const openWindow = (url: string): void => {
+  if (typeof window === 'undefined') return;
+
+  window.open(url, '_blank', 'noopener,noreferrer');
+};

--- a/packages/web3-react/src/hooks/useConnectorBraveWallet.ts
+++ b/packages/web3-react/src/hooks/useConnectorBraveWallet.ts
@@ -1,11 +1,10 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isBraveWalletProvider } from '../helpers';
+import { hasInjected, isBraveWalletProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorCoin98.ts
+++ b/packages/web3-react/src/hooks/useConnectorCoin98.ts
@@ -1,10 +1,15 @@
 import invariant from 'tiny-invariant';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isAndroid, isIOS, isCoin98Provider } from '../helpers';
+import {
+  hasInjected,
+  isAndroid,
+  isIOS,
+  isCoin98Provider,
+  openWindow,
+} from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorExodus.ts
+++ b/packages/web3-react/src/hooks/useConnectorExodus.ts
@@ -1,11 +1,10 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isExodusProvider } from '../helpers';
+import { hasInjected, isExodusProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorGamestop.ts
+++ b/packages/web3-react/src/hooks/useConnectorGamestop.ts
@@ -1,11 +1,10 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isGamestopProvider } from '../helpers';
+import { hasInjected, isGamestopProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorImToken.ts
+++ b/packages/web3-react/src/hooks/useConnectorImToken.ts
@@ -1,11 +1,10 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isImTokenProvider } from '../helpers';
+import { hasInjected, isImTokenProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorMathWallet.ts
+++ b/packages/web3-react/src/hooks/useConnectorMathWallet.ts
@@ -1,9 +1,9 @@
 import invariant from 'tiny-invariant';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
+import { openWindow } from '../helpers';
 import {
   hasInjected,
   isAndroid,

--- a/packages/web3-react/src/hooks/useConnectorMetamask.ts
+++ b/packages/web3-react/src/hooks/useConnectorMetamask.ts
@@ -1,7 +1,6 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
@@ -9,6 +8,7 @@ import {
   hasInjected,
   isBraveWalletProvider,
   checkIfBraveBrowser,
+  openWindow,
 } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';

--- a/packages/web3-react/src/hooks/useConnectorOperaWallet.ts
+++ b/packages/web3-react/src/hooks/useConnectorOperaWallet.ts
@@ -1,11 +1,10 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isOperaWalletProvider } from '../helpers';
+import { hasInjected, isOperaWalletProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorTally.ts
+++ b/packages/web3-react/src/hooks/useConnectorTally.ts
@@ -1,10 +1,9 @@
 import invariant from 'tiny-invariant';
 import { useCallback } from 'react';
 import { InjectedConnector } from '@web3-react/injected-connector';
-import { openWindow } from '@lido-sdk/helpers';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isTallyProvider } from '../helpers';
+import { hasInjected, isTallyProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorTrust.ts
+++ b/packages/web3-react/src/hooks/useConnectorTrust.ts
@@ -1,11 +1,15 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isTrustProvider, isMobileOrTablet } from '../helpers';
+import {
+  hasInjected,
+  isTrustProvider,
+  isMobileOrTablet,
+  openWindow,
+} from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/src/hooks/useConnectorXdefi.ts
+++ b/packages/web3-react/src/hooks/useConnectorXdefi.ts
@@ -1,11 +1,10 @@
 import invariant from 'tiny-invariant';
 import warning from 'tiny-warning';
 import { useCallback } from 'react';
-import { openWindow } from '@lido-sdk/helpers';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { useConnectors } from './useConnectors';
 import { useWeb3 } from './useWeb3';
-import { hasInjected, isXdefiProvider } from '../helpers';
+import { hasInjected, isXdefiProvider, openWindow } from '../helpers';
 import { useForceDisconnect } from './useDisconnect';
 import { ConnectorHookArgs } from './types';
 

--- a/packages/web3-react/test/hooks/useConnectorBrave.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorBrave.test.ts
@@ -1,9 +1,9 @@
-jest.mock('@lido-sdk/helpers');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorBraveWallet } from '../../src/hooks/useConnectorBraveWallet';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorCoin98.test.ts
@@ -1,9 +1,9 @@
-jest.mock('@lido-sdk/helpers');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorCoin98 } from '../../src/hooks/useConnectorCoin98';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorExodus.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorExodus.test.ts
@@ -1,11 +1,11 @@
-jest.mock('@lido-sdk/helpers');
 jest.mock('tiny-warning');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorExodus } from '../../src/hooks/useConnectorExodus';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorGamestop.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorGamestop.test.ts
@@ -1,11 +1,11 @@
-jest.mock('@lido-sdk/helpers');
 jest.mock('tiny-warning');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useWeb3, useConnectors, useConnectorGamestop } from '../../src';
 
 const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;

--- a/packages/web3-react/test/hooks/useConnectorImToken.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorImToken.test.ts
@@ -1,5 +1,5 @@
-jest.mock('@lido-sdk/helpers');
 jest.mock('tiny-warning');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
@@ -12,7 +12,7 @@ jest.mock('../../src/helpers/ua', () => ({
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorImToken } from '../../src/hooks/useConnectorImToken';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorMathWallet.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorMathWallet.test.ts
@@ -1,9 +1,9 @@
-jest.mock('@lido-sdk/helpers');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorMathWallet } from '../../src/hooks/useConnectorMathWallet';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorMetamask.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorMetamask.test.ts
@@ -1,11 +1,11 @@
-jest.mock('@lido-sdk/helpers');
 jest.mock('tiny-warning');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorMetamask } from '../../src/hooks/useConnectorMetamask';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorOpera.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorOpera.test.ts
@@ -1,9 +1,9 @@
-jest.mock('@lido-sdk/helpers');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorOperaWallet, useWeb3, useConnectors } from '../../src';
 
 const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;

--- a/packages/web3-react/test/hooks/useConnectorTally.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorTally.test.ts
@@ -1,9 +1,9 @@
-jest.mock('@lido-sdk/helpers');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorTally } from '../../src/hooks/useConnectorTally';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorTrust.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorTrust.test.ts
@@ -1,5 +1,5 @@
-jest.mock('@lido-sdk/helpers');
 jest.mock('tiny-warning');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
@@ -12,7 +12,7 @@ jest.mock('../../src/helpers/ua', () => ({
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useConnectorTrust } from '../../src/hooks/useConnectorTrust';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useConnectors } from '../../src/hooks/useConnectors';

--- a/packages/web3-react/test/hooks/useConnectorXdefi.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorXdefi.test.ts
@@ -1,11 +1,11 @@
-jest.mock('@lido-sdk/helpers');
 jest.mock('tiny-warning');
+jest.mock('../../src/helpers/openWindow');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import warning from 'tiny-warning';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { openWindow } from '@lido-sdk/helpers';
+import { openWindow } from '../../src/helpers/openWindow';
 import { useWeb3, useConnectors, useConnectorXdefi } from '../../src';
 
 const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2384,13 +2384,6 @@
   dependencies:
     tiny-invariant "^1.1.0"
 
-"@lido-sdk/constants@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@lido-sdk/constants/-/constants-1.6.0.tgz#e7a9a231c4ee26d3cef6b48a4d92d64d56d6a9a5"
-  integrity sha512-7QAk1LmB5HlstxDMbZak9qWl4jh+HGbNRXTiG6difwCFEDLI3a36NnoWc9Ry9f2e6MpM1QKGOl6gg1IEmoF1PA==
-  dependencies:
-    tiny-invariant "^1.1.0"
-
 "@lido-sdk/contracts@2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@lido-sdk/contracts/-/contracts-2.0.4.tgz#dbb56b2d92334d507675889f7938d464961e15b6"
@@ -2399,7 +2392,7 @@
     "@lido-sdk/constants" "1.8.1"
     tiny-invariant "^1.1.0"
 
-"@lido-sdk/helpers@1.4.7", "@lido-sdk/helpers@^1.4.7":
+"@lido-sdk/helpers@1.4.7":
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/@lido-sdk/helpers/-/helpers-1.4.7.tgz#43f17ba9e24f3052e17d392fa925bc13d62f52da"
   integrity sha512-6SKk+Q73hF167XsI2rq3Dc/LTq8BobmdPxwce626ra7buvS8ZKp1NGp8jOPHHPTdF5/5Jo4KY9gxWjSukbq3+g==


### PR DESCRIPTION
### v1.0 is a release, which starts migration to wagmi

#### Overall changes to this moment:
  - Update TS to 4.9.5, tslib to 2.5.0, rollup to 3.15.0
  - Update build config: generate ESM modules only, update tsconfig, change packages exports
  - Workaround styled-components ESM issue
  - Add wagmi dependency
  - Use wagmi controllers for all WalletConnect wallets (WC v2 support)
  - Add a modular wallet adapter API
  - Use a wallet adapter API with wagmi injected controller for Exodus wallet
  - Remove most of @lido-sdk dependencies
  - Cleanup and other minor changes