### PR TITLE
Shim useWeb3, useSupportedChains

### DIFF
--- a/apps/demo-react/components/ProviderWeb3WithProps.tsx
+++ b/apps/demo-react/components/ProviderWeb3WithProps.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react';
-import { mainnet } from 'wagmi/chains';
+import { mainnet, goerli } from 'wagmi/chains';
 import { ProviderWeb3 } from 'reef-knot/web3-react';
 import { rpc } from '../util/rpc';
 
 const ProviderWeb3WithProps = (props: { children: ReactNode }) => (
   <ProviderWeb3
     defaultChainId={mainnet.id}
-    supportedChainIds={[mainnet.id]}
+    supportedChainIds={[mainnet.id, goerli.id]}
     rpc={rpc}
   >
     {props.children}

--- a/apps/demo-react/components/WalletInfo.tsx
+++ b/apps/demo-react/components/WalletInfo.tsx
@@ -1,14 +1,29 @@
-import { useWeb3, useConnectorInfo } from 'reef-knot/web3-react';
-import { useAccount } from 'wagmi';
+import {
+  useWeb3,
+  useConnectorInfo,
+  useSupportedChains,
+} from 'reef-knot/web3-react';
+import { useAccount, useNetwork } from 'wagmi';
 
 const WalletInfo = () => {
   const connectorInfo = useConnectorInfo();
+  const supportedChainsData = useSupportedChains();
+  const supportedChainIds = supportedChainsData.supportedChains.map(
+    (c) => c.chainId,
+  );
+
+  // Get data via web3-react
   const web3Info = useWeb3();
+
+  // Get data via wagmi
   const {
     address: wagmiAddress,
     status: wagmiStatus,
+    isConnected: wagmiIsConnected,
     connector,
   } = useAccount();
+
+  const { chain } = useNetwork();
 
   return (
     <div>
@@ -17,16 +32,32 @@ const WalletInfo = () => {
         <code>
           <p>providerName: {connectorInfo.providerName}</p>
           <p>connectorName: {connectorInfo.connectorName}</p>
-          <p>account(useWeb3): {web3Info.account}</p>
+          <p>
+            <b>shimmed useWeb3() data below</b>
+          </p>
+          <p>account: {web3Info.account}</p>
+          <p>active: {String(web3Info.active)}</p>
+          <p>error: {web3Info.error?.message}</p>
+          <p>Chain ID: {web3Info.chainId}</p>
+          <p>
+            <b>Supported Chains</b>
+          </p>
+          <p>
+            Chain is unsupported: {String(supportedChainsData.isUnsupported)}
+          </p>
+          <p>Supported chain IDs: {supportedChainIds?.join(',')}</p>
         </code>
       </div>
       <h4>wagmi data:</h4>
       <div>
         <code>
           <p>status: {wagmiStatus}</p>
+          <p>isConnected: {String(wagmiIsConnected)}</p>
           <p>address: {wagmiAddress}</p>
           <p>Connector ID: {connector?.id}</p>
           <p>Connector name: {connector?.name}</p>
+          <p>Chain ID: {chain?.id}</p>
+          <p>Chain is unsupported: {String(chain?.unsupported)}</p>
         </code>
       </div>
     </div>

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/web3-react@1.0.1
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@reef-knot/connect-wallet-modal": "1.0.1",
-    "@reef-knot/web3-react": "1.0.0",
+    "@reef-knot/web3-react": "1.0.1",
     "@reef-knot/ui-react": "1.0.0",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/core-react": "1.0.0",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/web3-react
 
+## 1.0.1
+
+### Patch Changes
+
+- Shim useWeb3, useSupportedChains to also support wagmi data
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/hooks/useWeb3.ts
+++ b/packages/web3-react/src/hooks/useWeb3.ts
@@ -1,4 +1,37 @@
 import { useWeb3React } from '@web3-react/core';
+import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
+import { useAccount, useNetwork, useConnect } from 'wagmi';
 
 export { UnsupportedChainIdError } from '@web3-react/core';
-export const useWeb3 = useWeb3React;
+
+// Shimming useWeb3React hook to also use data returned from wagmi
+export function useWeb3<T = any>(key?: string): Web3ReactContextInterface<T> {
+  const web3ReactData = useWeb3React();
+  const wagmiAccount = useAccount();
+  const wagmiNetwork = useNetwork();
+  const { error: wagmiError } = useConnect();
+
+  const account = web3ReactData.account || wagmiAccount?.address;
+  const active = web3ReactData.active || wagmiAccount?.isConnected;
+  const chainId = web3ReactData.chainId || wagmiNetwork?.chain?.id;
+  // wagmi and web3-react use the same Error type
+  // wagmi is first here because it can be null, but we need Error | undefined
+  const error = wagmiError || web3ReactData.error;
+
+  return {
+    ...web3ReactData,
+    chainId,
+    account,
+    active,
+    error,
+
+    // NOT SHIMMED FIELDS:
+    // library:
+    //   Web3Provider from ethers.js, we pass it to Web3ReactProvider via getLibrary()
+    //   Will be the same for wagmi and web3-react since they both use ethers.js
+    //   Not used from this hook anywhere
+    // connector:
+    //   AbstractConnector from @web3-react, used by @reef-knot/web3-react only for
+    //   useDisconnect, useConnectorInfo and useSupportedChains
+  };
+}

--- a/packages/web3-react/test/hooks/useConnectors.test.tsx
+++ b/packages/web3-react/test/hooks/useConnectors.test.tsx
@@ -1,3 +1,4 @@
+jest.mock('wagmi');
 jest.mock('@gnosis.pm/safe-apps-web3-react');
 jest.mock('@ethersproject/providers');
 jest.mock('../../src/hooks/useAutoConnect');
@@ -9,6 +10,7 @@ import { Web3Provider } from '@ethersproject/providers';
 import { renderHook as renderHookOnServer } from '@testing-library/react-hooks/server';
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { CHAINS } from '@lido-sdk/constants';
+import { useConnect } from "wagmi";
 import { useAutoConnect, useConnectors, useWeb3 } from '../../src';
 import { ProviderWeb3 } from '../../src/context';
 
@@ -21,9 +23,11 @@ const mockWeb3Provider = Web3Provider as jest.MockedClass<typeof Web3Provider>;
 const mockUseAutoConnect = useAutoConnect as jest.MockedFunction<
   typeof useAutoConnect
 >;
+const mockUseConnect = useConnect as jest.MockedFunction<typeof useConnect>;
 
 beforeEach(() => {
   mockUseAutoConnect.mockImplementation(() => true);
+  mockUseConnect.mockReturnValue({ error: null } as any);
 });
 
 afterEach(() => {

--- a/packages/web3-react/test/hooks/useSupportedChains.test.ts
+++ b/packages/web3-react/test/hooks/useSupportedChains.test.ts
@@ -1,16 +1,20 @@
+jest.mock('wagmi');
 jest.mock('../../src/hooks/useWeb3');
 jest.mock('../../src/hooks/useConnectors');
 
 import { renderHook } from '@testing-library/react-hooks';
+import { useNetwork } from "wagmi";
 import { useWeb3, UnsupportedChainIdError } from '../../src/hooks/useWeb3';
 import { useSupportedChains } from '../../src/hooks/useSupportedChains';
 
 const mockUseWeb3 = useWeb3 as jest.MockedFunction<typeof useWeb3>;
+const mockUseNetwork = useNetwork as jest.MockedFunction<typeof useNetwork>;
 
 describe('useSupportedChains', () => {
   test('should return supportedChains correctly', async () => {
     const supportedChainIds = [1, 4];
     mockUseWeb3.mockReturnValue({ connector: { supportedChainIds } } as any);
+    mockUseNetwork.mockReturnValue({ chain: undefined, chains: []} as any);
 
     const { result } = renderHook(() => useSupportedChains());
     expect(result.current.supportedChains).toEqual(
@@ -21,6 +25,7 @@ describe('useSupportedChains', () => {
   test('should detect unsupported network', async () => {
     const error = new UnsupportedChainIdError(1);
     mockUseWeb3.mockReturnValue({ error } as any);
+    mockUseNetwork.mockReturnValue({ chain: undefined, chains: []} as any);
 
     const { result } = renderHook(() => useSupportedChains());
     expect(result.current.isUnsupported).toBe(true);


### PR DESCRIPTION
The main changes are in [useWeb3.ts](https://github.com/lidofinance/reef-knot/compare/shim-wagmi?expand=1#diff-81b322b317f6cfab3801b9a83eab36a6e837bce9451e83d77616f62f1617b3bc) and [useSupportedChains.ts](https://github.com/lidofinance/reef-knot/compare/shim-wagmi?expand=1#diff-09a7cccdcc9ddef855a86be9775530256399960ed3107052cecb16887b6271b1)
A user can connect a wallet either via legacy web3-react connector or via wagmi connector. In the first case, data from wagmi can be undefined. In the second case, data from web3-react can be undefined.
The `useWeb3` hook is used on our staking widget to get data from a wallet, so the shims were added to pass output both from web3-react AND wagmi.
