### PR TITLE
Set compilerOptions.jsx = "react"

### DIFF
--- a/packages/connect-wallet-modal/src/components/Terms/Terms.tsx
+++ b/packages/connect-wallet-modal/src/components/Terms/Terms.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC } from 'react';
+import React, { ChangeEvent, FC } from 'react';
 import { Checkbox, CheckboxProps, Link } from '@reef-knot/ui-react';
 import { TermsStyle, TermsTextStyle } from './styles';
 import { Metrics } from '../WalletsModal';

--- a/packages/connect-wallet-modal/src/components/WalletsModal/LidoModalLogo.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/LidoModalLogo.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 
 const LidoModalLogo = (): ReactElement => {
   return (

--- a/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Modal } from '@reef-knot/ui-react';
 import {
   WalletsModalProps,

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectInjected.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectInjected.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnect, useDisconnect } from 'wagmi';
 import { ConnectButton } from '../components';
 import { capitalize } from '../helpers';

--- a/packages/connect-wallet-modal/src/connectButtons/connectAmbire.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectAmbire.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import WalletConnectProvider from '@walletconnect/ethereum-provider';
 import { Ambire } from '@reef-knot/wallets-icons/react';
 import { useConnect, useDisconnect } from 'wagmi';

--- a/packages/connect-wallet-modal/src/connectButtons/connectBlockchaincom.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBlockchaincom.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import {
   Blockchaincom,
   BlockchaincomInversion,

--- a/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorBraveWallet, helpers } from '@reef-knot/web3-react';
 import { Brave as WalletIcon } from '@reef-knot/wallets-icons/react';
 import { CONFLICTS } from '../constants/conflictChecks';

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorCoin98 } from '@reef-knot/web3-react';
 import { Coin98 } from '@reef-knot/wallets-icons/react';
 import { CONFLICTS } from '../constants/conflictChecks';

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoinbase.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoinbase.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorCoinbase } from '@reef-knot/web3-react';
 import { Coinbase } from '@reef-knot/wallets-icons/react';
 import { ConnectWalletProps } from './types';

--- a/packages/connect-wallet-modal/src/connectButtons/connectExodus.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectExodus.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorExodus, helpers } from '@reef-knot/web3-react';
 import { Link } from '@reef-knot/ui-react';
 import { Exodus as WalletIcon } from '@reef-knot/wallets-icons/react';

--- a/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorGamestop, helpers } from '@reef-knot/web3-react';
 import { Gamestop as WalletIcon } from '@reef-knot/wallets-icons/react';
 import { CONFLICTS } from '../constants/conflictChecks';

--- a/packages/connect-wallet-modal/src/connectButtons/connectImToken.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectImToken.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorImToken } from '@reef-knot/web3-react';
 import { ImToken as WalletIcon } from '@reef-knot/wallets-icons/react';
 import { ConnectWalletProps } from './types';

--- a/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorLedger } from '@reef-knot/web3-react';
 import { Ledger, LedgerInversion } from '@reef-knot/wallets-icons/react';
 import { ConnectWalletProps } from './types';

--- a/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import {
   MathWallet,
   MathWalletInversion,

--- a/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorMetamask } from '@reef-knot/web3-react';
 import {
   MetaMaskCircle,

--- a/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorOperaWallet } from '@reef-knot/web3-react';
 import { OperaWallet as WalletIcon } from '@reef-knot/wallets-icons/react';
 import { ConnectWalletProps } from './types';

--- a/packages/connect-wallet-modal/src/connectButtons/connectTally.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectTally.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorTally } from '@reef-knot/web3-react';
 import { Tally } from '@reef-knot/wallets-icons/react';
 import { ConnectWalletProps } from './types';

--- a/packages/connect-wallet-modal/src/connectButtons/connectTrust.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectTrust.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorTrust } from '@reef-knot/web3-react';
 import { Trust as WalletIcon } from '@reef-knot/wallets-icons/react';
 import { ConnectWalletProps } from './types';

--- a/packages/connect-wallet-modal/src/connectButtons/connectWalletConnect.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectWalletConnect.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { WalletConnect } from '@reef-knot/wallets-icons/react';
 import { useConnect, useDisconnect } from 'wagmi';
 import { RKConnectorWalletConnect } from '@reef-knot/core-react';

--- a/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { useConnectorXdefi } from '@reef-knot/web3-react';
 import { XDEFI as WalletIcon } from '@reef-knot/wallets-icons/react';
 import { CONFLICTS } from '../constants/conflictChecks';

--- a/packages/connect-wallet-modal/src/connectButtons/connectZenGo.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectZenGo.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import { ZenGo as WalletIcon } from '@reef-knot/wallets-icons/react';
 import WalletConnectProvider from '@walletconnect/ethereum-provider';
 import { useConnect, useDisconnect } from 'wagmi';

--- a/packages/connect-wallet-modal/src/connectButtons/connectZerion.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectZerion.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect } from 'react';
+import React, { FC, useCallback, useEffect } from 'react';
 import { Zerion as WalletIcon } from '@reef-knot/wallets-icons/react';
 import WalletConnectProvider from '@walletconnect/ethereum-provider';
 import { useConnect, useDisconnect } from 'wagmi';

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,3 +1,17 @@
-# `tsconfig`
+# tsconfig
 
 These are base shared `tsconfig.json`s from which all other `tsconfig.json`'s inherit from.
+
+## Notes
+
+### `react-library.json`
+#### react-jsx
+The legacy `react` option instead of `react-jsx` is being used
+for the `compilerOptions.jsx` field.     
+
+_Reason:_
+reef-knot supports react v17 at the moment of writing.
+It has an issue with ESM because it has no `exports`
+field in the `package.json`. It is fixed in react v18, and we
+can switch to `react-jsx` option after migrating to react v18.  
+More info: https://github.com/facebook/react/issues/20235

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "ES2020",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/packages/ui-react/src/components/button/Button.tsx
+++ b/packages/ui-react/src/components/button/Button.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 import { ButtonStyle, ButtonContentStyle } from './ButtonStyles';
 import { ButtonProps } from './types';
 import { useRipple } from './useRipple';

--- a/packages/ui-react/src/components/button/ButtonIcon.tsx
+++ b/packages/ui-react/src/components/button/ButtonIcon.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 import {
   ButtonWrapperStyle,
   ButtonIconStyle,

--- a/packages/ui-react/src/components/checkbox/Checkbox.tsx
+++ b/packages/ui-react/src/components/checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 import styled from '../../utils/styledWrapper.js';
 import { CheckboxProps } from './types';
 import {

--- a/packages/ui-react/src/components/link/Link.tsx
+++ b/packages/ui-react/src/components/link/Link.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 import { LinkStyle } from './LinkStyles';
 import { LinkProps } from './types';
 

--- a/packages/ui-react/src/components/modal/ModalExtra.tsx
+++ b/packages/ui-react/src/components/modal/ModalExtra.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 
 import { ModalExtraStyle } from './ModalExtraStyles';
 import { ModalExtraProps } from './types';

--- a/packages/ui-react/src/components/modal/ModalOverlay.tsx
+++ b/packages/ui-react/src/components/modal/ModalOverlay.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
 import ReactDOM from 'react-dom';
 import modalRoot from './modalRoot';
 import { useMergeRefs, useEscape, useLockScroll } from '../../hooks';

--- a/packages/ui-react/src/components/modal/ModalStyles.tsx
+++ b/packages/ui-react/src/components/modal/ModalStyles.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled, { css } from '../../utils/styledWrapper.js';
 import { Close, ArrowBack } from '../../icons';
 import { ButtonIcon } from '../button';

--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, memo, useMemo } from 'react';
+import React, { createContext, FC, memo, useMemo } from 'react';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';

--- a/packages/web3-react/src/context/web3.tsx
+++ b/packages/web3-react/src/context/web3.tsx
@@ -1,4 +1,4 @@
-import { memo, FC } from 'react';
+import React, { memo, FC } from 'react';
 import invariant from 'tiny-invariant';
 import {
   Web3Provider,


### PR DESCRIPTION
Typescript offers various [jsx compiling options](https://www.typescriptlang.org/tsconfig#jsx).
This PR sets `compilerOptions.jsx` field to use legacy `react` value instead of `react-jsx`.
Other changes are just side effects of this action.

#### Reason:
Currently, we use React v17 on Lido widgets, and reef-knot also supports React v17.
React v17 has an issue with ESM because it has no `exports` field in the `package.json`.
This can cause such error during building a based on react v17 project, which uses ESM and imports reef-knot:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<...>\node_modules\react\jsx-runtime' imported from <...>
Did you mean to import react/jsx-runtime.js?
```
It happens because of the way how ESM in node.js is defined. In modules with a `package.json` containing `"type": "module"` imports in `.mjs` or `.js` files must be fully specified (with extensions), or it can be solved by the `exports` field.

It worked before because reef-knot was built as a CJS module.
The issue is fixed in react v18 – they've added the [`exports` field to `package.json`](https://github.com/facebook/react/blob/main/packages/react/package.json#L28), so we can switch back to `react-jsx` option after migrating to react v18.  
#### More info:
- https://github.com/facebook/react/issues/20235
- https://github.com/facebook/react/pull/20304
- https://github.com/adazzle/react-data-grid/issues/2568
- https://github.com/aws-amplify/amplify-ui/pull/3287#discussion_r1066481967
- https://github.com/webpack/webpack/issues/11467#issuecomment-691702706