### PR TITLE
Fix: account and providerWeb3 via wagmi

### DIFF
--- a/apps/demo-react/components/ConnectDisconnect.tsx
+++ b/apps/demo-react/components/ConnectDisconnect.tsx
@@ -1,16 +1,16 @@
 import { Button } from 'reef-knot/ui-react';
-import { useForceDisconnect } from 'reef-knot/web3-react';
-import { useDisconnect } from 'wagmi';
+import { useDisconnect as useDisconnectWeb3React } from 'reef-knot/web3-react';
+import { useDisconnect as useDisconnectWagmi } from 'wagmi';
 
 const ConnectDisconnect = (props: { handleOpen: () => void }) => {
   const { handleOpen } = props;
-  const { disconnect } = useForceDisconnect();
-  const { disconnect: wagmiDisconnect } = useDisconnect();
+  const { disconnect } = useDisconnectWeb3React();
+  const { disconnect: disconnectWagmi } = useDisconnectWagmi();
   const handleDisconnect = () => {
     // disconnect wallets connected through web3-react connectors
     disconnect?.();
     // disconnect wallets connected through wagmi connectors
-    wagmiDisconnect();
+    disconnectWagmi();
   };
 
   return (

--- a/apps/demo-react/components/WalletsModal.tsx
+++ b/apps/demo-react/components/WalletsModal.tsx
@@ -1,4 +1,3 @@
-import { mainnet, goerli } from 'wagmi/chains';
 import { WalletsModalForEth } from 'reef-knot/connect-wallet-modal';
 import metrics from '../util/metrics';
 
@@ -7,7 +6,6 @@ export default function WalletsModal(props: {
   handleClose: () => void;
 }) {
   const { open, handleClose } = props;
-  const wagmiChains = [mainnet, goerli];
 
   return (
     <WalletsModalForEth
@@ -15,7 +13,6 @@ export default function WalletsModal(props: {
       onClose={handleClose}
       metrics={metrics}
       walletConnectProjectId="cbbbf9cd4c2a5581edd36dc8cabe664f"
-      wagmiChains={wagmiChains}
     />
   );
 }

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.0.4
+
+### Patch Changes
+
+- Remove wagmiChains props, make walletConnectProjectId optional
+- Updated dependencies
+  - @reef-knot/web3-react@1.0.3
+
 ## 1.0.3
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,7 +41,7 @@
     "@reef-knot/ui-react": "^1.0.1",
     "@reef-knot/wallets-icons": "^1.0.0",
     "@reef-knot/wallets-list": "^1.0.0",
-    "@reef-knot/web3-react": "^1.0.2",
+    "@reef-knot/web3-react": "^1.0.3",
     "@types/react": "17.0.53",
     "@types/ua-parser-js": "^0.7.36",
     "ethers": "^5.7.2",
@@ -54,7 +54,7 @@
     "@reef-knot/ui-react": "^1.0.1",
     "@reef-knot/wallets-icons": "^1.0.0",
     "@reef-knot/wallets-list": "^1.0.0",
-    "@reef-knot/web3-react": "^1.0.2",
+    "@reef-knot/web3-react": "^1.0.3",
     "@walletconnect/ethereum-provider": "^1.8.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",

--- a/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
@@ -16,7 +16,6 @@ export function WalletsModal(props: WalletsModalProps): JSX.Element {
     buttonsFullWidth = false,
     metrics,
     walletConnectProjectId,
-    wagmiChains,
   } = props;
 
   const [termsChecked, setTermsChecked] = useLocalStorage(
@@ -42,7 +41,6 @@ export function WalletsModal(props: WalletsModalProps): JSX.Element {
   );
 
   const buttonsCommonProps: ButtonsCommonProps = {
-    wagmiChains,
     walletConnectProjectId,
     disabled: !termsChecked,
     onConnect: onClose,

--- a/packages/connect-wallet-modal/src/components/WalletsModal/types.ts
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/types.ts
@@ -20,7 +20,7 @@ export type WalletsModalProps = ModalProps & {
   shouldInvertWalletIcon?: boolean;
   buttonsFullWidth?: boolean;
   metrics?: Metrics;
-  walletConnectProjectId: string;
+  walletConnectProjectId?: string;
   wagmiChains: Chain[];
 };
 
@@ -31,6 +31,6 @@ export type ButtonsCommonProps = {
   shouldInvertWalletIcon: boolean;
   setRequirements(isVisible: boolean, requirementsData: RequirementsData): void;
   metrics?: Metrics;
-  walletConnectProjectId: string;
+  walletConnectProjectId?: string;
   wagmiChains: Chain[];
 };

--- a/packages/connect-wallet-modal/src/components/WalletsModal/types.ts
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/types.ts
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 import { ModalProps } from '@reef-knot/ui-react';
-import { Chain } from 'wagmi/chains';
 
 export type RequirementsData = {
   icon?: ReactNode;
@@ -21,7 +20,6 @@ export type WalletsModalProps = ModalProps & {
   buttonsFullWidth?: boolean;
   metrics?: Metrics;
   walletConnectProjectId?: string;
-  wagmiChains: Chain[];
 };
 
 export type ButtonsCommonProps = {
@@ -32,5 +30,4 @@ export type ButtonsCommonProps = {
   setRequirements(isVisible: boolean, requirementsData: RequirementsData): void;
   metrics?: Metrics;
   walletConnectProjectId?: string;
-  wagmiChains: Chain[];
 };

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.0.4
+  - @reef-knot/web3-react@1.0.3
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -40,8 +40,8 @@
     "dev": "dev=on rollup -c -w"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.0.3",
-    "@reef-knot/web3-react": "1.0.2",
+    "@reef-knot/connect-wallet-modal": "1.0.4",
+    "@reef-knot/web3-react": "1.0.3",
     "@reef-knot/ui-react": "1.0.1",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/core-react": "1.0.0",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/web3-react
 
+## 1.0.3
+
+### Patch Changes
+
+- - Get account address from the shimmed `useWeb3` hook
+  - Fix setting `providerWeb3` when a wallet is connected via wagmi
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/context/web3.tsx
+++ b/packages/web3-react/src/context/web3.tsx
@@ -8,8 +8,9 @@ import {
 import { CHAINS } from '@lido-sdk/constants';
 import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
 import { ProviderSDK as ProviderSDKBase } from '@lido-sdk/react';
-import { Web3ReactProvider, useWeb3React } from '@web3-react/core';
+import { Web3ReactProvider } from '@web3-react/core';
 import { SWRConfiguration } from 'swr';
+import { useWeb3 } from '../hooks/index';
 import { POLLING_INTERVAL } from '../constants';
 import ProviderConnectors, { ConnectorsContextProps } from './connectors';
 
@@ -36,7 +37,7 @@ const ProviderSDK: FC<ProviderWeb3Props> = (props) => {
     pollingInterval = POLLING_INTERVAL,
     ...rest
   } = props;
-  const { chainId = defaultChainId, library, account } = useWeb3React();
+  const { chainId = defaultChainId, library, account } = useWeb3();
 
   invariant(rpc[chainId], `RPC url for chain ${chainId} is not provided`);
   invariant(rpc[CHAINS.Mainnet], 'RPC url for mainnet is not provided');

--- a/packages/web3-react/src/context/web3.tsx
+++ b/packages/web3-react/src/context/web3.tsx
@@ -1,4 +1,4 @@
-import React, { memo, FC } from 'react';
+import React, { memo, FC, useEffect, useState } from 'react';
 import invariant from 'tiny-invariant';
 import {
   Web3Provider,
@@ -9,6 +9,7 @@ import { CHAINS } from '@lido-sdk/constants';
 import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
 import { ProviderSDK as ProviderSDKBase } from '@lido-sdk/react';
 import { Web3ReactProvider } from '@web3-react/core';
+import { useAccount } from 'wagmi';
 import { SWRConfiguration } from 'swr';
 import { useWeb3 } from '../hooks/index';
 import { POLLING_INTERVAL } from '../constants';
@@ -38,6 +39,18 @@ const ProviderSDK: FC<ProviderWeb3Props> = (props) => {
     ...rest
   } = props;
   const { chainId = defaultChainId, library, account } = useWeb3();
+  const [providerWeb3, setProviderWeb3] = useState(library);
+
+  // attempt to get providerWeb3 from wagmi
+  const { connector: connectorWagmi, isConnected } = useAccount();
+  useEffect(() => {
+    (async () => {
+      if (isConnected && !providerWeb3 && connectorWagmi) {
+        const p = await connectorWagmi.getProvider();
+        setProviderWeb3(getLibrary(p));
+      }
+    })();
+  }, [connectorWagmi, isConnected, providerWeb3]);
 
   invariant(rpc[chainId], `RPC url for chain ${chainId} is not provided`);
   invariant(rpc[CHAINS.Mainnet], 'RPC url for mainnet is not provided');
@@ -60,7 +73,7 @@ const ProviderSDK: FC<ProviderWeb3Props> = (props) => {
     <ProviderSDKBase
       chainId={chainId}
       supportedChainIds={supportedChainIds}
-      providerWeb3={library}
+      providerWeb3={providerWeb3}
       providerRpc={providerRpc}
       providerMainnetRpc={providerMainnetRpc}
       account={account ?? undefined}

--- a/packages/web3-react/test/hooks/useConnectors.test.tsx
+++ b/packages/web3-react/test/hooks/useConnectors.test.tsx
@@ -10,7 +10,7 @@ import { Web3Provider } from '@ethersproject/providers';
 import { renderHook as renderHookOnServer } from '@testing-library/react-hooks/server';
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { CHAINS } from '@lido-sdk/constants';
-import { useConnect } from "wagmi";
+import { useAccount, useConnect } from 'wagmi';
 import { useAutoConnect, useConnectors, useWeb3 } from '../../src';
 import { ProviderWeb3 } from '../../src/context';
 
@@ -24,14 +24,18 @@ const mockUseAutoConnect = useAutoConnect as jest.MockedFunction<
   typeof useAutoConnect
 >;
 const mockUseConnect = useConnect as jest.MockedFunction<typeof useConnect>;
+const mockUseAccount = useAccount as jest.MockedFunction<typeof useAccount>;
 
 beforeEach(() => {
   mockUseAutoConnect.mockImplementation(() => true);
   mockUseConnect.mockReturnValue({ error: null } as any);
+  mockUseAccount.mockReturnValue({ connector: {}, isConnected: false } as any);
 });
 
 afterEach(() => {
   mockUseAutoConnect.mockReset();
+  mockUseConnect.mockReset();
+  mockUseAccount.mockReset();
   mockSafeAppConnector.mockReset();
   mockWeb3Provider.mockReset();
 });


### PR DESCRIPTION
This PR fixes:
1. Get account address from the shimmed `useWeb3` hook, which works with wagmi, instead of a direct `useWeb3` call from `@web3-react/core`.
2. `providerWeb3` is crucial for transactions, and it wasn't set properly in case of connection via wagmi. I wasn't able to catch this flaw using the demo app, but it became obvious during testing on our widget.
3. A minor cosmetic update for `demo-react` app.