### PR TITLE
Fixes after code review, add `icon` to Wallet Adapter API

### DIFF
--- a/apps/demo-react/.eslintrc.json
+++ b/apps/demo-react/.eslintrc.json
@@ -21,7 +21,7 @@
     },
     "ecmaVersion": 12,
     "sourceType": "module",
-    "project": ["./packages/**/tsconfig.json", "./apps/**/tsconfig.json"]
+    "project": ["tsconfig.json"]
   },
   "plugins": ["@typescript-eslint", "react", "@next/next"],
   "rules": {
@@ -61,18 +61,12 @@
     "no-restricted-syntax": "off",
     "no-case-declarations": "off"
   },
-  "overrides": [{
-    "files": [ "./packages/wallets/**/src/**/*" ],
-    "rules": {
-      "import/no-extraneous-dependencies": "warn"
-    }
-  }],
   "settings": {
     "react": {
       "version": "detect"
     },
     "next": {
-      "rootDir": ["apps/*/"]
+      "rootDir": ["./"]
     },
     "import/resolver": {
       "typescript": {}

--- a/apps/demo-react/components/ConnectDisconnect.tsx
+++ b/apps/demo-react/components/ConnectDisconnect.tsx
@@ -19,9 +19,7 @@ const ConnectDisconnect = (props: { handleOpen: () => void }) => {
       <Button
         style={{ width: '200px', marginTop: '10px', alignSelf: 'center' }}
         variant="text"
-        onClick={() => {
-          handleDisconnect();
-        }}
+        onClick={handleDisconnect}
       >
         Disconnect
       </Button>

--- a/apps/demo-react/components/WalletsModal.tsx
+++ b/apps/demo-react/components/WalletsModal.tsx
@@ -4,14 +4,16 @@ import metrics from '../util/metrics';
 export default function WalletsModal(props: {
   open: boolean;
   handleClose: () => void;
+  isDarkTheme: boolean;
 }) {
-  const { open, handleClose } = props;
+  const { open, isDarkTheme, handleClose } = props;
 
   return (
     <WalletsModalForEth
       open={open}
       onClose={handleClose}
       metrics={metrics}
+      shouldInvertWalletIcon={isDarkTheme}
       walletConnectProjectId="cbbbf9cd4c2a5581edd36dc8cabe664f"
     />
   );

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "next lint"
   },
   "dependencies": {
     "@lidofinance/lido-ui": "3.2.0",

--- a/apps/demo-react/pages/index.tsx
+++ b/apps/demo-react/pages/index.tsx
@@ -42,7 +42,11 @@ export function Web() {
                 <WalletInfo />
               </SettingsWrapper>
 
-              <WalletsModal open={state} handleClose={handleClose} />
+              <WalletsModal
+                open={state}
+                handleClose={handleClose}
+                isDarkTheme={selectedTheme === ThemeName.dark}
+              />
             </MainContainer>
           </ProviderWeb3WithProps>
         </Wagmi>

--- a/packages/connect-wallet-modal/.eslintrc.json
+++ b/packages/connect-wallet-modal/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ]
+}

--- a/packages/connect-wallet-modal/rollup.config.js
+++ b/packages/connect-wallet-modal/rollup.config.js
@@ -8,8 +8,8 @@ import { babel } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -37,16 +37,7 @@ export default {
     resolve({ extensions, preferBuiltins: true }),
     typescript({
       typescript: ts,
-      tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
+      tsconfig: 'tsconfig.json'
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/connect-wallet-modal/src/components/ConnectButton/ConnectButton.tsx
+++ b/packages/connect-wallet-modal/src/components/ConnectButton/ConnectButton.tsx
@@ -1,4 +1,5 @@
-import React, { FC, isValidElement } from 'react';
+import React, { ElementType, FC, isValidElement } from 'react';
+import { WalletAdapterData, WalletAdapterIcons } from '@reef-knot/types';
 import {
   ConnectButtonStyle,
   ConnectButtonContentStyle,
@@ -7,17 +8,34 @@ import {
 } from './styles';
 import { ConnectButtonProps } from '../../connectButtons/types';
 
+// Check that icon's type is WalletAdapterIcons by looking at its "light" and "dark" fields
+function isWalletAdapterIcons(
+  icon: WalletAdapterData['icon'],
+): icon is WalletAdapterIcons {
+  return Boolean(
+    icon &&
+      (icon as WalletAdapterIcons).light &&
+      (icon as WalletAdapterIcons).dark,
+  );
+}
+
 const ConnectButton: FC<ConnectButtonProps> = (props: ConnectButtonProps) => {
-  const { iconSrcOrReactElement, children, ...rest } = props;
+  const { icon, shouldInvertWalletIcon, children, ...rest } = props;
+
+  let ButtonIcon: ElementType = React.Fragment;
+  if (icon) {
+    if (isWalletAdapterIcons(icon)) {
+      ButtonIcon = shouldInvertWalletIcon ? icon.dark : icon.light;
+    } else {
+      ButtonIcon = icon;
+    }
+  }
 
   return (
     <ConnectButtonStyle {...rest}>
       <ConnectButtonContentStyle>
         <ConnectButtonIconStyle>
-          {typeof iconSrcOrReactElement === 'string' && (
-            <img src={iconSrcOrReactElement} alt="" />
-          )}
-          {isValidElement(iconSrcOrReactElement) && iconSrcOrReactElement}
+          {isValidElement(<ButtonIcon />) && <ButtonIcon />}
         </ConnectButtonIconStyle>
         <ConnectButtonTitleStyle>{children}</ConnectButtonTitleStyle>
       </ConnectButtonContentStyle>

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectInjected.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectInjected.tsx
@@ -17,6 +17,7 @@ export const ConnectInjected: FC<ConnectInjectedProps> = (
     walletId,
     walletName,
     icons,
+    icon,
     downloadURLs,
     detector,
     connector,
@@ -58,11 +59,13 @@ export const ConnectInjected: FC<ConnectInjectedProps> = (
     walletIsDetected,
   ]);
 
-  const WalletIcon = shouldInvertWalletIcon ? icons.dark : icons.light;
+  const WalletIcon = icon || icons;
+
   return (
     <ConnectButton
       {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
+      icon={WalletIcon}
+      shouldInvertWalletIcon={shouldInvertWalletIcon}
       onClick={handleConnect}
     >
       {walletName}

--- a/packages/connect-wallet-modal/src/connectButtons/connectAmbire.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectAmbire.tsx
@@ -76,11 +76,7 @@ const ConnectAmbire: FC<ConnectWalletProps> = (props) => {
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<Ambire />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={Ambire} onClick={handleConnect}>
       Ambire
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectBlockchaincom.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBlockchaincom.tsx
@@ -51,11 +51,7 @@ const ConnectBlockchaincom: FC<ConnectWalletProps> = (props) => {
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       Blockchain.com
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectBraveWallet.tsx
@@ -86,11 +86,7 @@ const ConnectBraveWallet: FC<ConnectWalletProps> = (
   }, [onBeforeConnect, onClickBrave, handleConflicts, connect]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       Brave
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoin98.tsx
@@ -56,11 +56,7 @@ const ConnectCoin98: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   }, [connect, onBeforeConnect, onClickCoin98, setRequirements]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<Coin98 />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={Coin98} onClick={handleConnect}>
       Coin98
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectCoinbase.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectCoinbase.tsx
@@ -24,11 +24,7 @@ const ConnectCoinbase: FC<ConnectWalletProps> = (props) => {
   }, [connect, onBeforeConnect, onClickCoinbase]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<Coinbase />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={Coinbase} onClick={handleConnect}>
       Coinbase
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectGamestop.tsx
@@ -86,11 +86,7 @@ const ConnectGamestop: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       GameStop
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectImToken.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectImToken.tsx
@@ -33,11 +33,7 @@ const ConnectImToken: FC<ConnectWalletProps> = (props) => {
   }, [onBeforeConnect, onClickImToken, connect, setRequirements]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       imToken
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectLedger.tsx
@@ -46,11 +46,7 @@ const ConnectLedger: FC<ConnectWalletProps> = (props) => {
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       Ledger
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMathWallet.tsx
@@ -73,11 +73,7 @@ const ConnectMathWallet: FC<ConnectWalletProps> = (
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       MathWallet
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectMetamask.tsx
@@ -69,11 +69,7 @@ const ConnectMetamask: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   }, [connect, onBeforeConnect, onClickMetamask, setRequirements, WalletIcon]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       MetaMask
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectOperaWallet.tsx
@@ -37,11 +37,7 @@ const ConnectOperaWallet: FC<ConnectWalletProps> = (
   }, [onBeforeConnect, onClickOperaWallet, connect]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       Opera
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectTally.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectTally.tsx
@@ -40,11 +40,7 @@ const ConnectTally: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   }, [connect, onBeforeConnect, onClickTally, setRequirements]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<Tally />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={Tally} onClick={handleConnect}>
       Tally
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectTrust.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectTrust.tsx
@@ -56,11 +56,7 @@ const ConnectTrust: FC<ConnectWalletProps> = (props) => {
   }, [connect, onBeforeConnect, onClickTrust, setRequirements]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       Trust Wallet
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectWalletConnect.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectWalletConnect.tsx
@@ -31,11 +31,7 @@ const ConnectWalletConnect: FC<ConnectWalletProps> = (props) => {
   }, [onBeforeConnect, onClickWC, disconnectAsync, connectAsync, connector]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletConnect />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletConnect} onClick={handleConnect}>
       WalletConnect
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectXdefi.tsx
@@ -48,11 +48,7 @@ const ConnectXdefi: FC<ConnectWalletProps> = (props: ConnectWalletProps) => {
   }, [connect, onBeforeConnect, onClickXdefi, setRequirements]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       XDEFI
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectZenGo.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectZenGo.tsx
@@ -85,11 +85,7 @@ const ConnectZenGo: FC<ConnectWalletProps> = (props) => {
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       ZenGo
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/connectZerion.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/connectZerion.tsx
@@ -85,11 +85,7 @@ const ConnectZerion: FC<ConnectWalletProps> = (props) => {
   ]);
 
   return (
-    <ConnectButton
-      {...rest}
-      iconSrcOrReactElement={<WalletIcon />}
-      onClick={handleConnect}
-    >
+    <ConnectButton {...rest} icon={WalletIcon} onClick={handleConnect}>
       Zerion
     </ConnectButton>
   );

--- a/packages/connect-wallet-modal/src/connectButtons/types.ts
+++ b/packages/connect-wallet-modal/src/connectButtons/types.ts
@@ -1,10 +1,10 @@
-import { ReactElement } from 'react';
 import { ButtonProps } from '@reef-knot/ui-react';
 import { WalletAdapterData } from '@reef-knot/types';
 import { ButtonsCommonProps } from '../components';
 
 export type ConnectButtonProps = {
-  iconSrcOrReactElement: string | ReactElement;
+  icon: WalletAdapterData['icon'];
+  shouldInvertWalletIcon?: boolean;
 } & ButtonProps;
 
 export type ConnectWalletProps = ButtonsCommonProps & ButtonProps;

--- a/packages/connect-wallet-modal/src/helpers/openWindow.ts
+++ b/packages/connect-wallet-modal/src/helpers/openWindow.ts
@@ -1,5 +1,3 @@
 export const openWindow = (url: string): void => {
-  if (typeof window === 'undefined') return;
-
-  window.open(url, '_blank', 'noopener,noreferrer');
+  globalThis.window?.open(url, '_blank', 'noopener,noreferrer');
 };

--- a/packages/connect-wallet-modal/tsconfig.json
+++ b/packages/connect-wallet-modal/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/core-react/.eslintrc.json
+++ b/packages/core-react/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ]
+}

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -33,7 +33,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "dev": "dev=on rollup -c -w"
+    "dev": "dev=on rollup -c -w",
+    "lint": "eslint"
   },
   "devDependencies": {
     "react": "17.0.2",

--- a/packages/core-react/rollup.config.js
+++ b/packages/core-react/rollup.config.js
@@ -8,8 +8,8 @@ import { babel } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -38,15 +38,6 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/core-react/src/walletData/index.ts
+++ b/packages/core-react/src/walletData/index.ts
@@ -10,10 +10,9 @@ export const walletDataList = walletAdapters.map((walletAdapter) =>
 );
 
 export const getConnectors = ({ rpc }: { rpc: Record<number, string> }) => {
-  const connectors: Connector[] = [];
-  walletDataList.forEach((walletData) => {
-    connectors.push(walletData.connector);
-  });
+  const connectors: Connector[] = [...walletDataList].map(
+    (walletData) => walletData.connector,
+  );
 
   const connectorsWC = createConnectorsWalletConnect({ rpc });
   return [...connectorsWC, ...connectors];

--- a/packages/core-react/tsconfig.json
+++ b/packages/core-react/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -1,0 +1,72 @@
+module.exports = {
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "airbnb",
+    "@lidofinance",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:jsx-a11y/recommended",
+    "plugin:prettier/recommended",
+    "turbo"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "project": ["tsconfig.json"]
+  },
+  "plugins": ["@typescript-eslint", "react"],
+  "rules": {
+    "prettier/prettier": ["error", {}, { "usePrettierrc": true }],
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-filename-extension": "off",
+    "react/prop-types": "off",
+    "react/destructuring-assignment": "off",
+    "react/require-default-props": "off",
+    "react/jsx-props-no-spreading": "off",
+    "react/function-component-definition": "off",
+    "react/jsx-one-expression-per-line": "off",
+    "react/jsx-no-duplicate-props": ["error", { "ignoreCase": false }],
+    "react/jsx-no-bind": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "ignoreRestSiblings": true,
+        "argsIgnorePattern": "^_"
+      }
+    ],
+    "import/prefer-default-export": "off",
+    "import/extensions": "off",
+    "import/no-mutable-exports": "off",
+    "jsx-a11y/anchor-is-valid": "off",
+    "func-names": "off",
+    "no-console": "off",
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+    "consistent-return": "off",
+    "no-use-before-define": "off",
+    "no-underscore-dangle": "off",
+    "no-bitwise": "off",
+    "no-return-await": "off",
+    "no-nested-ternary": "off",
+    "no-restricted-syntax": "off",
+    "no-case-declarations": "off"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    },
+    "import/resolver": {
+      "typescript": {}
+    }
+  },
+  "ignorePatterns": ["*.js", "dist", "node_modules"]
+}

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "eslint-config-custom",
+  "version": "0.0.0",
+  "private": true,
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ]
+}

--- a/packages/reef-knot/.eslintrc.json
+++ b/packages/reef-knot/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ]
+}

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -37,7 +37,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "dev": "dev=on rollup -c -w"
+    "dev": "dev=on rollup -c -w",
+    "lint": "eslint"
   },
   "dependencies": {
     "@reef-knot/connect-wallet-modal": "1.0.5",

--- a/packages/reef-knot/rollup.config.js
+++ b/packages/reef-knot/rollup.config.js
@@ -7,8 +7,8 @@ import { babel } from '@rollup/plugin-babel';
 import process from 'process';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -36,15 +36,6 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/reef-knot/tsconfig.json
+++ b/packages/reef-knot/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/types/rollup.config.js
+++ b/packages/types/rollup.config.js
@@ -7,8 +7,8 @@ import { babel } from '@rollup/plugin-babel';
 import process from 'process';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -36,15 +36,6 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/types/src/walletAdapter.ts
+++ b/packages/types/src/walletAdapter.ts
@@ -1,16 +1,20 @@
 import { ElementType } from 'react';
 import { Connector } from 'wagmi';
 
+export type WalletAdapterIcons = {
+  light: ElementType;
+  dark: ElementType;
+};
+
 export type WalletAdapterData = {
   walletId: string;
   walletName: string;
 
   // Icons for the light and dark color themes.
-  // You can use different icons or the same for both cases.
-  icons: {
-    light: ElementType;
-    dark: ElementType;
-  };
+  // You can use different icons or the same icon for both cases.
+  icon?: ElementType | WalletAdapterIcons;
+  // Deprecated, use "icon" instead, TODO: remove
+  icons?: WalletAdapterIcons;
 
   // A function to check if the wallet is installed and injected.
   // For example: isMetaMaskProvider: () => !!window.ethereum?.isMetaMask

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
-  "compilerOptions": {
-    "emitDeclarationOnly": true
-  },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/ui-react/.eslintrc.json
+++ b/packages/ui-react/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ]
+}

--- a/packages/ui-react/rollup.config.js
+++ b/packages/ui-react/rollup.config.js
@@ -9,8 +9,8 @@ import { babel } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -38,16 +38,7 @@ export default {
     resolve({ extensions, preferBuiltins: true }),
     typescript({
       typescript: ts,
-      tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: './src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
+      tsconfig: 'tsconfig.json'
     }),
     commonjs(),
     babel({

--- a/packages/ui-react/src/components/modal/ModalStyles.tsx
+++ b/packages/ui-react/src/components/modal/ModalStyles.tsx
@@ -3,7 +3,7 @@ import styled, { css } from '../../utils/styledWrapper.js';
 import { Close, ArrowBack } from '../../icons';
 import { ButtonIcon } from '../button';
 
-const MaxInnerWidth = 600;
+const MAX_INNER_WIDTH = 600;
 
 export const ModalStyle = styled.div<{ $center: boolean }>`
   ${({
@@ -35,7 +35,7 @@ export const ModalHeaderStyle = styled.div<{
   $short: boolean;
 }>`
   ${({ theme: { spaceMap, fontSizesMap, mediaQueries }, $short }) => css`
-    max-width: ${MaxInnerWidth}px;
+    max-width: ${MAX_INNER_WIDTH}px;
     min-height: 32px;
     display: flex;
     align-items: flex-start;
@@ -103,7 +103,7 @@ export const ModalSubtitleStyle = styled.div`
     line-height: 24px;
     margin-top: -${spaceMap.xl}px;
     padding: 0 ${spaceMap.xxl}px ${spaceMap.sm}px;
-    max-width: ${MaxInnerWidth}px;
+    max-width: ${MAX_INNER_WIDTH}px;
 
     ${mediaQueries.md} {
       padding-left: ${spaceMap.xl}px;
@@ -114,7 +114,7 @@ export const ModalSubtitleStyle = styled.div`
 
 export const ModalContentStyle = styled.div`
   ${({ theme: { spaceMap, mediaQueries } }) => css`
-    max-width: ${MaxInnerWidth}px;
+    max-width: ${MAX_INNER_WIDTH}px;
     padding: 0 ${spaceMap.xxl}px 0;
 
     ${mediaQueries.md} {

--- a/packages/ui-react/tsconfig.json
+++ b/packages/ui-react/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/wallets-icons/.eslintrc.json
+++ b/packages/wallets-icons/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ]
+}

--- a/packages/wallets-icons/rollup.config.js
+++ b/packages/wallets-icons/rollup.config.js
@@ -8,8 +8,8 @@ import { babel } from '@rollup/plugin-babel';
 import svgr from '@svgr/rollup';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx', '.svg'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -44,15 +44,6 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets-icons/tsconfig.json
+++ b/packages/wallets-icons/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/wallets-list/.eslintrc.json
+++ b/packages/wallets-list/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ]
+}

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -33,7 +33,8 @@
   },
   "scripts": {
     "build": "rollup -c",
-    "dev": "dev=on rollup -c -w"
+    "dev": "dev=on rollup -c -w",
+    "lint": "eslint"
   },
   "dependencies": {
     "@reef-knot/wallet-adapter-exodus": "1.0.1"

--- a/packages/wallets-list/rollup.config.js
+++ b/packages/wallets-list/rollup.config.js
@@ -8,8 +8,8 @@ import { babel } from '@rollup/plugin-babel';
 import json from '@rollup/plugin-json';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -38,15 +38,6 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets-list/tsconfig.json
+++ b/packages/wallets-list/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/wallets/exodus/.eslintrc.json
+++ b/packages/wallets/exodus/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ],
+  "rules": {
+    "import/no-extraneous-dependencies": "warn"
+  }
+}

--- a/packages/wallets/exodus/rollup.config.js
+++ b/packages/wallets/exodus/rollup.config.js
@@ -9,8 +9,8 @@ import { babel } from '@rollup/plugin-babel';
 import svgr from '@svgr/rollup';
 
 const extensions = ['.js', '.jsx', '.ts', '.tsx', '.svg'];
-const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-const { dependencies, peerDependencies } = packageJson;
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 const commonExternal = [
   'react/jsx-runtime',
   // Do not include in the bundle subpath exports like:
@@ -45,15 +45,6 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/exodus/src/index.ts
+++ b/packages/wallets/exodus/src/index.ts
@@ -14,10 +14,7 @@ declare global {
 export const Exodus: WalletAdapterType = () => ({
   walletName: 'Exodus',
   walletId: 'exodus',
-  icons: {
-    light: WalletIcon,
-    dark: WalletIcon,
-  },
+  icon: WalletIcon,
   detector: () =>
     typeof window !== 'undefined'
       ? !!window.exodus?.ethereum?.isExodus || !!window.ethereum?.isExodus

--- a/packages/wallets/exodus/src/index.ts
+++ b/packages/wallets/exodus/src/index.ts
@@ -1,13 +1,14 @@
 import { WalletAdapterType } from '@reef-knot/types';
-import { Ethereum } from '@wagmi/core';
+import { Ethereum as EthereumTypeWagmi } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import WalletIcon from './icons/exodus.svg';
 
 declare global {
+  interface Ethereum extends EthereumTypeWagmi {
+    isExodus?: true;
+  }
   interface Window {
-    // @ts-expect-error Subsequent property declarations must have the same type
-    ethereum?: Ethereum & { isExodus?: boolean };
-    exodus?: { ethereum?: Ethereum & { isExodus?: boolean } };
+    exodus?: { ethereum?: Ethereum };
   }
 }
 
@@ -16,9 +17,7 @@ export const Exodus: WalletAdapterType = () => ({
   walletId: 'exodus',
   icon: WalletIcon,
   detector: () =>
-    typeof window !== 'undefined'
-      ? !!window.exodus?.ethereum?.isExodus || !!window.ethereum?.isExodus
-      : false,
+    !!globalThis.window?.exodus || !!globalThis.window?.ethereum?.isExodus,
   downloadURLs: {
     default: 'https://www.exodus.com/download/',
   },
@@ -26,9 +25,7 @@ export const Exodus: WalletAdapterType = () => ({
     options: {
       name: 'Exodus',
       getProvider: () =>
-        typeof window !== 'undefined'
-          ? window.exodus?.ethereum || window.ethereum
-          : undefined,
+        globalThis.window?.exodus?.ethereum || globalThis.window?.ethereum,
     },
   }),
 });

--- a/packages/wallets/exodus/tsconfig.json
+++ b/packages/wallets/exodus/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"]
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
 }

--- a/packages/web3-react/.eslintrc.json
+++ b/packages/web3-react/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ],
+  "ignorePatterns": ["test/**/*.test.*"]
+}


### PR DESCRIPTION
This PR is based on @Jabher review for this PR: https://github.com/lidofinance/reef-knot/pull/38

### The changes are:
- Reorganize eslint config to eliminate the error, quoted below. I decided to use the Turborepo guide: [ESLint in a monorepo](https://turbo.build/repo/docs/handbook/linting/eslint)

> demo-react:build: error - ESLint: Error while loading rule '@typescript-eslint/switch-exhaustiveness-check': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser. Occurred while linting /Users/jabher/WebstormProjects/reef-knot/apps/demo-react/pages/index.tsx

- Update Wallet Adapter API: use `icon` field instead of `icons`. But leave `icons` for a short time too for backward compatibility (until we merge PR's from external wallet teams).
- rollup config:
  - remove obsolete tsconfig options overriding https://github.com/lidofinance/reef-knot/pull/38#discussion_r1152180814
  - add default values for `dependencies`, `peerDependencies` https://github.com/lidofinance/reef-knot/pull/38#discussion_r1152180254
- Code style:
  - rename MaxInnerWidth to MAX_INNER_WIDTH https://github.com/lidofinance/reef-knot/pull/38#discussion_r1152181852
  - Exodus wallet adapter: extend Ethereum interface https://github.com/lidofinance/reef-knot/pull/38#discussion_r1152183302, update `detector`
  - Use `globalThis.window?` where applicable