### PR TITLE
Fixes for Reef Knot v1 after QA

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.0.8
+
+### Patch Changes
+
+- Tally => Taho in conflict checks
+- Reset the Terms acceptance for all users
+- Updated dependencies
+  - @reef-knot/web3-react@1.0.6
+
 ## 1.0.7
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,7 +41,7 @@
     "@reef-knot/types": "^1.0.0",
     "@reef-knot/ui-react": "^1.0.3",
     "@reef-knot/wallets-icons": "^1.0.0",
-    "@reef-knot/web3-react": "^1.0.5",
+    "@reef-knot/web3-react": "^1.0.6",
     "@types/react": "17.0.53",
     "@types/ua-parser-js": "^0.7.36",
     "ethers": "^5.7.2",
@@ -54,7 +54,7 @@
     "@reef-knot/types": "^1.0.0",
     "@reef-knot/ui-react": "^1.0.3",
     "@reef-knot/wallets-icons": "^1.0.0",
-    "@reef-knot/web3-react": "^1.0.5",
+    "@reef-knot/web3-react": "^1.0.6",
     "@walletconnect/ethereum-provider": "^1.8.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",

--- a/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
@@ -18,8 +18,12 @@ export function WalletsModal(props: WalletsModalProps): JSX.Element {
     walletConnectProjectId,
   } = props;
 
+  // This key can be changed to enforce all users to accept the Terms again,
+  // for example if the Terms were significantly updated
+  const TERMS_ACCEPTANCE_LS_KEY = 'reef-knot_accept-terms_n2';
+
   const [termsChecked, setTermsChecked] = useLocalStorage(
-    'reef-knot_terms-agree',
+    TERMS_ACCEPTANCE_LS_KEY,
     false,
   );
 

--- a/packages/connect-wallet-modal/src/constants/conflictChecks.ts
+++ b/packages/connect-wallet-modal/src/constants/conflictChecks.ts
@@ -14,7 +14,7 @@ export type ConflictChecks = {
 };
 
 export const CONFLICTS: ConflictChecks = {
-  Tally: [helpers.isTallyProvider, 'Tally'],
+  Tally: [helpers.isTallyProvider, 'Taho'],
   Exodus: [helpers.isExodusProvider, 'Exodus'],
   Coin98: [helpers.isCoin98Provider, 'Coin98'],
   MathWallet: [helpers.isMathWalletProvider, 'MathWallet'],

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 1.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/web3-react@1.0.6
+  - @reef-knot/connect-wallet-modal@1.0.8
+
 ## 1.0.8
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,8 +41,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.0.7",
-    "@reef-knot/web3-react": "1.0.5",
+    "@reef-knot/connect-wallet-modal": "1.0.8",
+    "@reef-knot/web3-react": "1.0.6",
     "@reef-knot/ui-react": "1.0.3",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/core-react": "1.0.1",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/web3-react
 
+## 1.0.6
+
+### Patch Changes
+
+- Fix setting a Web3Provider for web3-react
+- If the chain is unsupported and connected via wagmi, handle it the same way as web3-react does
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/context/web3.tsx
+++ b/packages/web3-react/src/context/web3.tsx
@@ -39,18 +39,23 @@ const ProviderSDK: FC<ProviderWeb3Props> = (props) => {
     ...rest
   } = props;
   const { chainId = defaultChainId, library, account } = useWeb3();
-  const [providerWeb3, setProviderWeb3] = useState(library);
+  const [providerWeb3, setProviderWeb3] = useState<Web3Provider>();
 
   // attempt to get providerWeb3 from wagmi
   const { connector: connectorWagmi, isConnected } = useAccount();
   useEffect(() => {
     (async () => {
       if (isConnected && !providerWeb3 && connectorWagmi) {
+        // Set wagmi provider
         const p = await connectorWagmi.getProvider();
         setProviderWeb3(getLibrary(p));
+      } else if (!providerWeb3) {
+        // Set web3-react provider
+        // Passing `library` as init value for useState does not work, but works like this:
+        setProviderWeb3(library);
       }
     })();
-  }, [connectorWagmi, isConnected, providerWeb3]);
+  }, [connectorWagmi, isConnected, library, providerWeb3]);
 
   invariant(rpc[chainId], `RPC url for chain ${chainId} is not provided`);
   invariant(rpc[CHAINS.Mainnet], 'RPC url for mainnet is not provided');

--- a/packages/web3-react/src/hooks/useSupportedChains.ts
+++ b/packages/web3-react/src/hooks/useSupportedChains.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { getNetwork, Network } from '@ethersproject/providers';
 import { useNetwork } from 'wagmi';
-import { useWeb3, UnsupportedChainIdError } from './useWeb3';
+import { useWeb3React, UnsupportedChainIdError } from '@web3-react/core';
 
 const STABLE_ARRAY: never[] = [];
 
@@ -13,7 +13,7 @@ export const useSupportedChains = (): {
   let isUnsupported: boolean;
 
   // legacy web3-react data
-  const { error, connector } = useWeb3();
+  const { error, connector } = useWeb3React();
   // wagmi data
   const { chain, chains } = useNetwork();
   const wagmiSupportedChainIds = useMemo(

--- a/packages/web3-react/src/hooks/useWeb3.ts
+++ b/packages/web3-react/src/hooks/useWeb3.ts
@@ -1,6 +1,7 @@
 import { useWeb3React } from '@web3-react/core';
 import { Web3ReactContextInterface } from '@web3-react/core/dist/types';
 import { useAccount, useNetwork, useConnect } from 'wagmi';
+import { useSupportedChains } from './useSupportedChains';
 
 export { UnsupportedChainIdError } from '@web3-react/core';
 
@@ -12,8 +13,29 @@ export function useWeb3<T = any>(key?: string): Web3ReactContextInterface<T> {
   const { error: wagmiError } = useConnect();
 
   const account = web3ReactData.account || wagmiAccount?.address;
-  const active = web3ReactData.active || wagmiAccount?.isConnected;
-  const chainId = web3ReactData.chainId || wagmiNetwork?.chain?.id;
+
+  // web3-react and wagmi have different logic around unsupported chains.
+  // If a chain is not supported:
+  // web3-react sets:
+  //   `chainId` === undefined
+  //   `error` === UnsupportedChainIdError
+  //   `active` === false
+  // wagmi sets:
+  //   `chain.id` === actual value from wallet
+  //   `chain.unsupported` === true
+  //   `error` === null
+  //   `isConnected` === true (connects via default chain)
+  // These differences break our widgets, because the widgets don't expect
+  // chainId to be unsupported, they expect chainId === undefined in that case.
+  // Making wagmi's logic to be the same as web3-react here, except setting an error:
+  const { isUnsupported } = useSupportedChains();
+  const chainId = isUnsupported
+    ? undefined
+    : web3ReactData.chainId || wagmiNetwork?.chain?.id;
+  const active = isUnsupported
+    ? false
+    : web3ReactData.active || wagmiAccount?.isConnected;
+
   // wagmi and web3-react use the same Error type
   // wagmi is first here because it can be null, but we need Error | undefined
   const error = wagmiError || web3ReactData.error;


### PR DESCRIPTION
### Changes
- Renames Tally to Taho in conflict checks too
- Reset "I have read and accept Terms of Service" checkbox for all users by updating a localStorage key. The reason is that Lido Terms were significantly updated recently and users should read and accept them one more time. In the future, it should be moved from Reef Knot to a widget level.
- Fix an incorrect setting of providerWeb3 in case of connecting via web3-react. For some reason, Web3Provider class instance can't be used as initial value in `useState()`, but can be set later using `set` function.
- Fix the issues related to choosing an unsupported chain in a wallet, connected via wagmi. The reason of the issues is that wagmi and web3-react have different logic for handling such case. And our widgets historically work with web3-react logic. So, for now, if a wallet connected via wagmi and the chosen network is unsupported, we will handle this case just like web3-react does.