### PR TITLE
Fix: OKX wallet position

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.1.1
+
+### Patch Changes
+
+- Improve the selection of the OKX wallet position
+
 ## 1.1.0
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connect-wallet-modal/src/components/WalletsModalForEth/WalletsModalForEth.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModalForEth/WalletsModalForEth.tsx
@@ -58,8 +58,10 @@ function getWalletButton(
 function addWalletTo(
   walletsList: string[],
   walletId: string,
-  condition: boolean,
+  condition: boolean, // meant to be a wallet-detector function result
 ) {
+  // If condition is true (usually means that a wallet is detected),
+  // move it to the first place in the wallets list, so a user can see it right away
   if (condition) {
     walletsList.unshift(walletId);
   } else {
@@ -106,9 +108,11 @@ function getWalletsButtons(
   // TODO: add better wallets ordering when all wallets migrated to wallet adapter API
   const okxWalletId = 'okx';
   const okxWalletIndex = wallets.indexOf(okxWalletId);
-  if (okxWalletIndex >= 0) {
-    wallets.splice(okxWalletIndex, 1);
-    wallets.splice(1, 0, okxWalletId);
+  const metamaskIndex = wallets.indexOf(WALLET_IDS.METAMASK);
+  // If metamask is there and okx was initially placed more than one step away from metamask
+  if (metamaskIndex > -1 && okxWalletIndex > metamaskIndex + 1) {
+    wallets.splice(okxWalletIndex, 1); // remove okx from its place
+    wallets.splice(metamaskIndex + 1, 0, okxWalletId); // place okx right after metamask
   }
 
   return wallets.map((walletId) => {

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.1.1
+
 ## 1.1.0
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,7 +41,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.1.0",
+    "@reef-knot/connect-wallet-modal": "1.1.1",
     "@reef-knot/web3-react": "1.0.6",
     "@reef-knot/ui-react": "1.0.3",
     "@reef-knot/wallets-icons": "1.0.0",


### PR DESCRIPTION
### Changes
Fix the issue when the OKX wallet button always took the second position in the list (it may be wrong sometimes), place it after metamask instead.
Add some comments to the code.