### PR TITLE
Fix(web3-react): web3 providers switch

### DIFF
--- a/.changeset/short-ladybugs-hug.md
+++ b/.changeset/short-ladybugs-hug.md
@@ -1,0 +1,6 @@
+---
+'@reef-knot/web3-react': patch
+---
+
+- Do not detect providerName if isDappBrowser;
+- Fix switching between web3 providers;

--- a/.changeset/short-ladybugs-hug.md
+++ b/.changeset/short-ladybugs-hug.md
@@ -1,6 +1,0 @@
----
-'@reef-knot/web3-react': patch
----
-
-- Do not detect providerName if isDappBrowser;
-- Fix switching between web3 providers;

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.1.2
+
+### Patch Changes
+
+- Updated dependencies [9da75b6]
+  - @reef-knot/web3-react@1.0.7
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@reef-knot/connect-wallet-modal": "1.1.1",
-    "@reef-knot/web3-react": "1.0.6",
+    "@reef-knot/web3-react": "1.0.7",
     "@reef-knot/ui-react": "1.0.3",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/core-react": "1.1.0",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/web3-react
 
+## 1.0.7
+
+### Patch Changes
+
+- Do not detect providerName if isDappBrowser;
+- Fix switching between web3 providers;
+
 ## 1.0.6
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/hooks/useWeb3.ts
+++ b/packages/web3-react/src/hooks/useWeb3.ts
@@ -50,8 +50,6 @@ export function useWeb3<T = any>(key?: string): Web3ReactContextInterface<T> {
     // NOT SHIMMED FIELDS:
     // library:
     //   Web3Provider from ethers.js, we pass it to Web3ReactProvider via getLibrary()
-    //   Will be the same for wagmi and web3-react since they both use ethers.js
-    //   Not used from this hook anywhere
     // connector:
     //   AbstractConnector from @web3-react, used by @reef-knot/web3-react only for
     //   useDisconnect, useConnectorInfo and useSupportedChains


### PR DESCRIPTION
Fixes ETHUI-415 and UI-620 – the issues with a wrong web3 providers switching when one wallet was disconnected and the other wallet is connected instead.