### PR TITLE
Add 'reefknot_wcv2_enable' localstorage flag

### DIFF
--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.3.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/wallets-helpers@1.0.2
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -47,7 +47,7 @@
     "@reef-knot/ui-react": "1.0.3",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/wallets-list": "1.3.1",
-    "@reef-knot/wallets-helpers": "1.0.1",
+    "@reef-knot/wallets-helpers": "1.0.2",
     "@reef-knot/types": "1.1.1"
   }
 }

--- a/packages/wallets-helpers/CHANGELOG.md
+++ b/packages/wallets-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallets-helpers
 
+## 1.0.2
+
+### Patch Changes
+
+- Add 'reefknot_wcv2_enable' localstorage flag to enable WC v2 for testing purposes
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-helpers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets-helpers/src/factories/walletConnectConnector.ts
+++ b/packages/wallets-helpers/src/factories/walletConnectConnector.ts
@@ -28,9 +28,14 @@ export const getWalletConnectConnector = ({
   qrcode?: boolean;
   v2?: boolean;
 }) => {
+  let v2EnabledByLS = false;
+  if (typeof window !== 'undefined') {
+    v2EnabledByLS =
+      window.localStorage.getItem('reefknot_wcv2_enable') === 'true';
+  }
   // WalletConnect v2 will automatically replace legacy v1 after this date:
-  const v2TransitionDate = new Date('2023-06-20T00:00:00Z');
-  const v2 = _v2 || new Date() > v2TransitionDate;
+  const v2TransitionDate = new Date('2023-06-24T00:00:00Z');
+  const v2 = _v2 || v2EnabledByLS || new Date() > v2TransitionDate;
   if (v2) {
     return new WalletConnectConnector({
       options: {


### PR DESCRIPTION
The flag is needed for testing purposes of WalletConnect v2.
To enable WC v2 QR modal, run this in the dev console and restart the page:
```
window.localStorage.setItem('reefknot_wcv2_enable', 'true')
```

Also moves the date of autoswitching to WC v2 to 24.06 from 20.06