### PR TITLE
Fix (reef-knot 1.4): pass chains to wagmi connectors, update wagmi to v0.12.16

### DIFF
--- a/apps/demo-react/components/ProviderWeb3WithProps.tsx
+++ b/apps/demo-react/components/ProviderWeb3WithProps.tsx
@@ -6,7 +6,7 @@ import { WC_PROJECT_ID } from '../util/walletconnectProjectId';
 
 const ProviderWeb3WithProps = (props: { children: ReactNode }) => (
   <ProviderWeb3
-    defaultChainId={mainnet.id}
+    defaultChainId={goerli.id}
     supportedChainIds={[mainnet.id, goerli.id]}
     rpc={rpc}
     walletconnectProjectId={WC_PROJECT_ID}

--- a/apps/demo-react/components/Wagmi.tsx
+++ b/apps/demo-react/components/Wagmi.tsx
@@ -6,7 +6,7 @@ import { getConnectors } from 'reef-knot/core-react';
 import { rpc } from '../util/rpc';
 import { WC_PROJECT_ID } from '../util/walletconnectProjectId';
 
-const { provider, webSocketProvider } = configureChains(
+const { chains, provider, webSocketProvider } = configureChains(
   [mainnet, goerli],
   [publicProvider()],
 );
@@ -14,6 +14,8 @@ const { provider, webSocketProvider } = configureChains(
 const connectors = getConnectors({
   rpc,
   walletconnectProjectId: WC_PROJECT_ID,
+  chains,
+  defaultChain: goerli,
 });
 
 const client = createClient({

--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -18,7 +18,7 @@
     "react-dom": "17.0.2",
     "reef-knot": "*",
     "styled-components": "^5.3.6",
-    "wagmi": "^0.12.12"
+    "wagmi": "^0.12.16"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.4.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -47,7 +47,7 @@
     "ethers": "^5.7.2",
     "react": "17.0.2",
     "ua-parser-js": "1.0.33",
-    "wagmi": "^0.12.12"
+    "wagmi": "^0.12.16"
   },
   "peerDependencies": {
     "@reef-knot/core-react": "^1.3.1",
@@ -57,6 +57,6 @@
     "@reef-knot/web3-react": "^1.1.1",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
-    "wagmi": "^0.12.12"
+    "wagmi": "^0.12.16"
   }
 }

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,11 +37,11 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/core-react": "^1.3.1",
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/core-react": "^1.4.0",
+    "@reef-knot/types": "^1.2.0",
     "@reef-knot/ui-react": "^1.0.3",
     "@reef-knot/wallets-icons": "^1.0.0",
-    "@reef-knot/web3-react": "^1.1.1",
+    "@reef-knot/web3-react": "^1.2.0",
     "@types/react": "17.0.53",
     "@types/ua-parser-js": "^0.7.36",
     "ethers": "^5.7.2",
@@ -50,11 +50,11 @@
     "wagmi": "^0.12.16"
   },
   "peerDependencies": {
-    "@reef-knot/core-react": "^1.3.1",
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/core-react": "^1.4.0",
+    "@reef-knot/types": "^1.2.0",
     "@reef-knot/ui-react": "^1.0.3",
     "@reef-knot/wallets-icons": "^1.0.0",
-    "@reef-knot/web3-react": "^1.1.1",
+    "@reef-knot/web3-react": "^1.2.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
     "wagmi": "^0.12.16"

--- a/packages/core-react/CHANGELOG.md
+++ b/packages/core-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @reef-knot/core-react
 
+## 1.4.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/core-react",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -39,13 +39,13 @@
   "devDependencies": {
     "react": "17.0.2",
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-list": "^1.3.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-list": "^1.4.0",
+    "@reef-knot/types": "^1.2.0"
   },
   "peerDependencies": {
     "react": ">=17",
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-list": "^1.3.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-list": "^1.4.0",
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -38,13 +38,13 @@
   },
   "devDependencies": {
     "react": "17.0.2",
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-list": "^1.3.1",
     "@reef-knot/types": "^1.1.1"
   },
   "peerDependencies": {
     "react": ">=17",
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-list": "^1.3.1",
     "@reef-knot/types": "^1.1.1"
   }

--- a/packages/core-react/src/context/index.tsx
+++ b/packages/core-react/src/context/index.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, FC, useMemo } from 'react';
 import { WalletAdapterData } from '@reef-knot/types';
+import { Chain } from 'wagmi/chains';
 import { getWalletDataList } from '../walletData/index';
 
 export interface ReefKnotContextProps {
   rpc: Record<number, string>;
   walletconnectProjectId?: string;
+  chains: Chain[];
+  defaultChain?: Chain;
 }
 
 export type ReefKnotContextValue = {
@@ -17,9 +20,16 @@ export const ReefKnotContext = createContext({} as ReefKnotContextValue);
 export const ReefKnot: FC<ReefKnotContextProps> = ({
   rpc,
   walletconnectProjectId,
+  chains,
+  defaultChain,
   children,
 }) => {
-  const walletDataList = getWalletDataList({ rpc, walletconnectProjectId });
+  const walletDataList = getWalletDataList({
+    rpc,
+    walletconnectProjectId,
+    chains,
+    defaultChain,
+  });
 
   const contextValue = useMemo(
     () => ({ rpc, walletDataList }),

--- a/packages/core-react/src/walletData/index.ts
+++ b/packages/core-react/src/walletData/index.ts
@@ -1,21 +1,33 @@
 import { WalletsListEthereum } from '@reef-knot/wallets-list';
 import { WalletAdapterData } from '@reef-knot/types';
+import type { Chain } from 'wagmi/chains';
 
 let walletDataList: undefined | WalletAdapterData[];
 
 export interface GetConnectorsArgs {
-  rpc: Record<number, string>;
+  rpc?: Record<number, string>;
   walletconnectProjectId?: string;
+  chains: Chain[];
+  defaultChain?: Chain;
 }
 
 export const getWalletDataList = ({
   rpc,
   walletconnectProjectId,
+  chains,
+  defaultChain,
 }: GetConnectorsArgs) => {
   const walletAdapters = Object.values(WalletsListEthereum);
   if (!walletDataList) {
+    // Sorting supported chains, so the default chain is always first in the array
+    // Have to do this because WalletConnect v2 via wagmi always tries to connect
+    // to the first chain in the chains array
+    const sortedChains = defaultChain
+      ? chains.sort((chain) => (chain.id === defaultChain.id ? -1 : 1))
+      : chains;
+
     walletDataList = walletAdapters.map((walletAdapter) =>
-      walletAdapter({ rpc, walletconnectProjectId }),
+      walletAdapter({ rpc, walletconnectProjectId, chains: sortedChains }),
     );
   }
   return walletDataList;

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,17 @@
 # reef-knot
 
+## 1.4.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.4.0
+  - @reef-knot/core-react@1.4.0
+  - @reef-knot/types@1.2.0
+  - @reef-knot/wallets-helpers@1.1.0
+  - @reef-knot/web3-react@1.2.0
+  - @reef-knot/wallets-list@1.4.0
+
 ## 1.3.3
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,13 +41,13 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.3.1",
-    "@reef-knot/core-react": "1.3.1",
-    "@reef-knot/web3-react": "1.1.1",
+    "@reef-knot/connect-wallet-modal": "1.4.0",
+    "@reef-knot/core-react": "1.4.0",
+    "@reef-knot/web3-react": "1.2.0",
     "@reef-knot/ui-react": "1.0.3",
     "@reef-knot/wallets-icons": "1.0.0",
-    "@reef-knot/wallets-list": "1.3.1",
-    "@reef-knot/wallets-helpers": "1.0.2",
-    "@reef-knot/types": "1.1.1"
+    "@reef-knot/wallets-list": "1.4.0",
+    "@reef-knot/wallets-helpers": "1.1.0",
+    "@reef-knot/types": "1.2.0"
   }
 }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/types
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,10 +27,10 @@
   },
   "devDependencies": {
     "react": "17.0.2",
-    "wagmi": "^0.12.12"
+    "wagmi": "^0.12.16"
   },
   "peerDependencies": {
     "react": ">=17",
-    "wagmi": "^0.12.12"
+    "wagmi": "^0.12.16"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/types",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/packages/types/src/walletAdapter.ts
+++ b/packages/types/src/walletAdapter.ts
@@ -1,5 +1,6 @@
 import { ElementType } from 'react';
 import { Connector } from 'wagmi';
+import type { Chain } from 'wagmi/chains';
 
 export type WalletAdapterIcons = {
   light: ElementType;
@@ -49,8 +50,9 @@ export type WalletAdapterData = {
 };
 
 export interface WalletAdapterArgs {
-  rpc: Record<number, string>;
+  rpc?: Record<number, string>;
   walletconnectProjectId?: string;
+  chains: Chain[];
 }
 export type WalletAdapterType = (args: WalletAdapterArgs) => WalletAdapterData;
 

--- a/packages/wallets-helpers/CHANGELOG.md
+++ b/packages/wallets-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallets-helpers
 
+## 1.1.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -37,12 +37,12 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "wagmi": "0.12.12",
+    "wagmi": "^0.12.16",
     "ua-parser-js": "1.0.33"
   },
   "peerDependencies": {
     "react": ">=17",
-    "wagmi": "0.12.12",
+    "wagmi": "^0.12.16",
     "ua-parser-js": "1.0.33"
   }
 }

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-helpers",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets-helpers/src/factories/walletConnectConnector.ts
+++ b/packages/wallets-helpers/src/factories/walletConnectConnector.ts
@@ -46,8 +46,6 @@ export const getWalletConnectConnector = ({
         projectId,
         showQrModal: qrcode,
         qrModalOptions: {
-          explorerAllowList: undefined,
-          explorerDenyList: undefined,
           themeVariables: {
             '--w3m-z-index': '1000',
           },

--- a/packages/wallets-helpers/src/factories/walletConnectConnector.ts
+++ b/packages/wallets-helpers/src/factories/walletConnectConnector.ts
@@ -1,9 +1,10 @@
 import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import { Chain } from 'wagmi/chains';
 import { isValidHttpUrl } from '../utils';
 import { walletConnectMobileLinks } from './walletConnectMobileLinks';
 
-export const prepareWalletConnectRPC = (rpc: Record<number, string>) => {
+export const prepareWalletConnectRPC = (rpc: Record<number, string> = {}) => {
   const BASE_URL = typeof window === 'undefined' ? '' : window.location.origin;
   // adds BASE_URL to `rpc` object's string values
   return Object.entries(rpc).reduce(
@@ -21,12 +22,14 @@ export const getWalletConnectConnector = ({
   noMobileLinks = false,
   qrcode = true,
   v2: _v2 = false,
+  chains,
 }: {
-  rpc: Record<number, string>;
+  rpc?: Record<number, string>;
   projectId?: string;
   noMobileLinks?: boolean;
   qrcode?: boolean;
   v2?: boolean;
+  chains: Chain[];
 }) => {
   let v2EnabledByLS = false;
   if (typeof window !== 'undefined') {
@@ -38,6 +41,7 @@ export const getWalletConnectConnector = ({
   const v2 = _v2 || v2EnabledByLS || new Date() > v2TransitionDate;
   if (v2) {
     return new WalletConnectConnector({
+      chains,
       options: {
         projectId,
         showQrModal: qrcode,
@@ -52,6 +56,7 @@ export const getWalletConnectConnector = ({
     });
   }
   return new WalletConnectLegacyConnector({
+    chains,
     options: {
       rpc: prepareWalletConnectRPC(rpc),
       qrcode,

--- a/packages/wallets-helpers/src/factories/walletConnectConnector.ts
+++ b/packages/wallets-helpers/src/factories/walletConnectConnector.ts
@@ -46,6 +46,8 @@ export const getWalletConnectConnector = ({
         projectId,
         showQrModal: qrcode,
         qrModalOptions: {
+          // @walletconnect library currently requires the "chainImages" option, looks like their mistake
+          chainImages: undefined,
           themeVariables: {
             '--w3m-z-index': '1000',
           },

--- a/packages/wallets-list/CHANGELOG.md
+++ b/packages/wallets-list/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallets-list
 
+## 1.4.0
+
+### Patch Changes
+
+- Updated dependencies
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-list",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,21 +37,21 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@reef-knot/wallet-adapter-exodus": "1.1.1",
-    "@reef-knot/wallet-adapter-taho": "1.1.1",
-    "@reef-knot/wallet-adapter-okx": "1.1.1",
-    "@reef-knot/wallet-adapter-phantom": "1.1.1",
-    "@reef-knot/wallet-adapter-walletconnect": "1.1.1",
-    "@reef-knot/wallet-adapter-blockchaincom": "1.1.1",
-    "@reef-knot/wallet-adapter-zerion": "1.1.1",
-    "@reef-knot/wallet-adapter-zengo": "1.1.1",
-    "@reef-knot/wallet-adapter-ambire": "1.1.1"
+    "@reef-knot/wallet-adapter-exodus": "1.2.0",
+    "@reef-knot/wallet-adapter-taho": "1.2.0",
+    "@reef-knot/wallet-adapter-okx": "1.2.0",
+    "@reef-knot/wallet-adapter-phantom": "1.2.0",
+    "@reef-knot/wallet-adapter-walletconnect": "1.2.0",
+    "@reef-knot/wallet-adapter-blockchaincom": "1.2.0",
+    "@reef-knot/wallet-adapter-zerion": "1.2.0",
+    "@reef-knot/wallet-adapter-zengo": "1.2.0",
+    "@reef-knot/wallet-adapter-ambire": "1.2.0"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/types": "^1.2.0"
   },
   "peerDependencies": {
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/types": "^1.2.0",
     "react": ">=17"
   }
 }

--- a/packages/wallets/ambire/CHANGELOG.md
+++ b/packages/wallets/ambire/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @reef-knot/wallet-adapter-ambire
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+  - @reef-knot/wallets-helpers@1.1.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/ambire/package.json
+++ b/packages/wallets/ambire/package.json
@@ -37,7 +37,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-helpers": "^1.0.1",
     "@reef-knot/types": "^1.1.1"
   }

--- a/packages/wallets/ambire/package.json
+++ b/packages/wallets/ambire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ambire",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
-    "@reef-knot/wallets-helpers": "^1.0.1",
+    "@reef-knot/types": "^1.2.0",
+    "@reef-knot/wallets-helpers": "^1.1.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-helpers": "^1.0.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-helpers": "^1.1.0",
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/ambire/src/index.ts
+++ b/packages/wallets/ambire/src/index.ts
@@ -2,11 +2,16 @@ import { WalletAdapterType } from '@reef-knot/types';
 import { getWalletConnectConnector } from '@reef-knot/wallets-helpers';
 import WalletIcon from './icons/ambire.svg';
 
-export const Ambire: WalletAdapterType = ({ rpc, walletconnectProjectId }) => ({
+export const Ambire: WalletAdapterType = ({
+  rpc,
+  walletconnectProjectId,
+  chains,
+}) => ({
   walletName: 'Ambire',
   walletId: 'ambire',
   icon: WalletIcon,
   connector: getWalletConnectConnector({
+    chains,
     rpc,
     noMobileLinks: true,
     projectId: walletconnectProjectId,
@@ -14,6 +19,7 @@ export const Ambire: WalletAdapterType = ({ rpc, walletconnectProjectId }) => ({
   walletconnectExtras: {
     connectionViaURI: {
       connector: getWalletConnectConnector({
+        chains,
         rpc,
         qrcode: false,
         projectId: walletconnectProjectId,

--- a/packages/wallets/blockchaincom/CHANGELOG.md
+++ b/packages/wallets/blockchaincom/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @reef-knot/wallet-adapter-blockchaincom
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+  - @reef-knot/wallets-helpers@1.1.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/blockchaincom/package.json
+++ b/packages/wallets/blockchaincom/package.json
@@ -37,7 +37,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-helpers": "^1.0.1",
     "@reef-knot/types": "^1.1.1"
   }

--- a/packages/wallets/blockchaincom/package.json
+++ b/packages/wallets/blockchaincom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-blockchaincom",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
-    "@reef-knot/wallets-helpers": "^1.0.1",
+    "@reef-knot/types": "^1.2.0",
+    "@reef-knot/wallets-helpers": "^1.1.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-helpers": "^1.0.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-helpers": "^1.1.0",
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/blockchaincom/src/index.ts
+++ b/packages/wallets/blockchaincom/src/index.ts
@@ -6,6 +6,7 @@ import WalletIconInverted from './icons/blockchaincom-inverted.svg';
 export const Blockchaincom: WalletAdapterType = ({
   rpc,
   walletconnectProjectId,
+  chains,
 }) => ({
   walletName: 'Blockchain.com',
   walletId: 'blockchaincom',
@@ -14,6 +15,7 @@ export const Blockchaincom: WalletAdapterType = ({
     dark: WalletIconInverted,
   },
   connector: getWalletConnectConnector({
+    chains,
     rpc,
     projectId: walletconnectProjectId,
     noMobileLinks: true,

--- a/packages/wallets/exodus/CHANGELOG.md
+++ b/packages/wallets/exodus/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @reef-knot/wallet-adapter-exodus
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -36,7 +36,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/types": "^1.1.1"
   }
 }

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-exodus",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,11 +32,11 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/types": "^1.2.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/exodus/src/index.ts
+++ b/packages/wallets/exodus/src/index.ts
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-export const Exodus: WalletAdapterType = () => ({
+export const Exodus: WalletAdapterType = ({ chains }) => ({
   walletName: 'Exodus',
   walletId: 'exodus',
   icon: WalletIcon,
@@ -22,6 +22,7 @@ export const Exodus: WalletAdapterType = () => ({
     default: 'https://www.exodus.com/download/',
   },
   connector: new InjectedConnector({
+    chains,
     options: {
       name: 'Exodus',
       getProvider: () =>

--- a/packages/wallets/okx/CHANGELOG.md
+++ b/packages/wallets/okx/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @reef-knot/wallet-adapter-okx
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-okx",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,11 +32,11 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/types": "^1.2.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -36,7 +36,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/types": "^1.1.1"
   }
 }

--- a/packages/wallets/okx/src/index.ts
+++ b/packages/wallets/okx/src/index.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-export const Okx: WalletAdapterType = () => ({
+export const Okx: WalletAdapterType = ({ chains }) => ({
   walletName: 'OKX Wallet',
   walletId: 'okx',
   icons: {
@@ -30,6 +30,7 @@ export const Okx: WalletAdapterType = () => ({
     default: 'https://www.okx.com/download',
   },
   connector: new InjectedConnector({
+    chains,
     options: {
       name: 'OKX Wallet',
       getProvider: () =>

--- a/packages/wallets/phantom/CHANGELOG.md
+++ b/packages/wallets/phantom/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @reef-knot/wallet-adapter-phantom
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -36,7 +36,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/types": "^1.1.1"
   }
 }

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-phantom",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,11 +32,11 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/types": "^1.2.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/phantom/src/index.ts
+++ b/packages/wallets/phantom/src/index.ts
@@ -15,7 +15,7 @@ declare global {
   }
 }
 
-export const Phantom: WalletAdapterType = () => ({
+export const Phantom: WalletAdapterType = ({ chains }) => ({
   walletName: 'Phantom',
   walletId: 'phantom',
   icons: {
@@ -29,6 +29,7 @@ export const Phantom: WalletAdapterType = () => ({
     default: 'https://phantom.app/download',
   },
   connector: new InjectedConnector({
+    chains,
     options: {
       name: 'Phantom',
       getProvider: () =>

--- a/packages/wallets/taho/CHANGELOG.md
+++ b/packages/wallets/taho/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @reef-knot/wallet-adapter-taho
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/taho/package.json
+++ b/packages/wallets/taho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-taho",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,11 +32,11 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
+    "@reef-knot/types": "^1.2.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/taho/package.json
+++ b/packages/wallets/taho/package.json
@@ -36,7 +36,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/types": "^1.1.1"
   }
 }

--- a/packages/wallets/taho/src/index.ts
+++ b/packages/wallets/taho/src/index.ts
@@ -16,7 +16,7 @@ declare global {
 }
 
 // The wallet was named "Tally Ho" previously, renamed to "Taho"
-export const Taho: WalletAdapterType = () => ({
+export const Taho: WalletAdapterType = ({ chains }) => ({
   walletName: 'Taho',
   // The current metrics implementation is based on walletId,
   // using previous "tally" name here not to break metrics
@@ -28,6 +28,7 @@ export const Taho: WalletAdapterType = () => ({
     default: 'https://taho.xyz/download/',
   },
   connector: new InjectedConnector({
+    chains,
     options: {
       name: 'Taho',
       getProvider: () =>

--- a/packages/wallets/walletconnect/CHANGELOG.md
+++ b/packages/wallets/walletconnect/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @reef-knot/wallet-adapter-walletconnect
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+  - @reef-knot/wallets-helpers@1.1.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-walletconnect",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
-    "@reef-knot/wallets-helpers": "^1.0.1",
+    "@reef-knot/types": "^1.2.0",
+    "@reef-knot/wallets-helpers": "^1.1.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-helpers": "^1.0.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-helpers": "^1.1.0",
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -37,7 +37,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-helpers": "^1.0.1",
     "@reef-knot/types": "^1.1.1"
   }

--- a/packages/wallets/walletconnect/src/index.ts
+++ b/packages/wallets/walletconnect/src/index.ts
@@ -5,11 +5,13 @@ import WalletIcon from './icons/wallet-connect-circle.svg';
 export const WalletConnect: WalletAdapterType = ({
   rpc,
   walletconnectProjectId,
+  chains,
 }) => ({
   walletName: 'WalletConnect',
   walletId: 'walletconnect',
   icon: WalletIcon,
   connector: getWalletConnectConnector({
+    chains,
     rpc,
     projectId: walletconnectProjectId,
   }),

--- a/packages/wallets/zengo/CHANGELOG.md
+++ b/packages/wallets/zengo/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @reef-knot/wallet-adapter-zengo
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+  - @reef-knot/wallets-helpers@1.1.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/zengo/package.json
+++ b/packages/wallets/zengo/package.json
@@ -37,7 +37,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-helpers": "^1.0.1",
     "@reef-knot/types": "^1.1.1"
   }

--- a/packages/wallets/zengo/package.json
+++ b/packages/wallets/zengo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-zengo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
-    "@reef-knot/wallets-helpers": "^1.0.1",
+    "@reef-knot/types": "^1.2.0",
+    "@reef-knot/wallets-helpers": "^1.1.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-helpers": "^1.0.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-helpers": "^1.1.0",
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/zengo/src/index.ts
+++ b/packages/wallets/zengo/src/index.ts
@@ -5,11 +5,16 @@ import {
 } from '@reef-knot/wallets-helpers';
 import WalletIcon from './icons/zengo.svg';
 
-export const Zengo: WalletAdapterType = ({ rpc, walletconnectProjectId }) => ({
+export const Zengo: WalletAdapterType = ({
+  rpc,
+  walletconnectProjectId,
+  chains,
+}) => ({
   walletName: 'ZenGo',
   walletId: 'zengo',
   icon: WalletIcon,
   connector: getWalletConnectConnector({
+    chains,
     rpc,
     noMobileLinks: true,
     projectId: walletconnectProjectId,
@@ -17,6 +22,7 @@ export const Zengo: WalletAdapterType = ({ rpc, walletconnectProjectId }) => ({
   walletconnectExtras: {
     connectionViaURI: {
       connector: getWalletConnectConnector({
+        chains,
         rpc,
         qrcode: false,
         projectId: walletconnectProjectId,

--- a/packages/wallets/zerion/CHANGELOG.md
+++ b/packages/wallets/zerion/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @reef-knot/wallet-adapter-zerion
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@1.2.0
+  - @reef-knot/wallets-helpers@1.1.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/wallets/zerion/package.json
+++ b/packages/wallets/zerion/package.json
@@ -37,7 +37,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": "^0.12.12",
+    "wagmi": "^0.12.16",
     "@reef-knot/wallets-helpers": "^1.0.1",
     "@reef-knot/types": "^1.1.1"
   }

--- a/packages/wallets/zerion/package.json
+++ b/packages/wallets/zerion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-zerion",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint"
   },
   "devDependencies": {
-    "@reef-knot/types": "^1.1.1",
-    "@reef-knot/wallets-helpers": "^1.0.1",
+    "@reef-knot/types": "^1.2.0",
+    "@reef-knot/wallets-helpers": "^1.1.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": "^0.12.16",
-    "@reef-knot/wallets-helpers": "^1.0.1",
-    "@reef-knot/types": "^1.1.1"
+    "@reef-knot/wallets-helpers": "^1.1.0",
+    "@reef-knot/types": "^1.2.0"
   }
 }

--- a/packages/wallets/zerion/src/index.ts
+++ b/packages/wallets/zerion/src/index.ts
@@ -5,11 +5,16 @@ import {
 } from '@reef-knot/wallets-helpers';
 import WalletIcon from './icons/zerion.svg';
 
-export const Zerion: WalletAdapterType = ({ rpc, walletconnectProjectId }) => ({
+export const Zerion: WalletAdapterType = ({
+  rpc,
+  walletconnectProjectId,
+  chains,
+}) => ({
   walletName: 'Zerion',
   walletId: 'zerion',
   icon: WalletIcon,
   connector: getWalletConnectConnector({
+    chains,
     rpc,
     noMobileLinks: true,
     projectId: walletconnectProjectId,
@@ -17,6 +22,7 @@ export const Zerion: WalletAdapterType = ({ rpc, walletconnectProjectId }) => ({
   walletconnectExtras: {
     connectionViaURI: {
       connector: getWalletConnectConnector({
+        chains,
         rpc,
         qrcode: false,
         projectId: walletconnectProjectId,

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @reef-knot/web3-react
 
+## 1.2.0
+
+### Minor Changes
+
+- Explicitly pass chains to wagmi connectors, update wagmi to v0.12.16
+
+### Patch Changes
+
+- Updated dependencies
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -84,6 +84,6 @@
     "@walletconnect/ethereum-provider": "^1.8.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
-    "wagmi": "^0.12.12"
+    "wagmi": "^0.12.16"
   }
 }

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -47,7 +47,7 @@
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.18.6",
     "@ethersproject/providers": "^5.7.2",
-    "@reef-knot/core-react": "^1.3.1",
+    "@reef-knot/core-react": "^1.4.0",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^29.4.0",
@@ -80,7 +80,7 @@
   },
   "peerDependencies": {
     "@ethersproject/providers": "5",
-    "@reef-knot/core-react": "^1.3.1",
+    "@reef-knot/core-react": "^1.4.0",
     "@walletconnect/ethereum-provider": "^1.8.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",

--- a/packages/web3-react/src/context/web3.tsx
+++ b/packages/web3-react/src/context/web3.tsx
@@ -11,6 +11,7 @@ import { ProviderSDK as ProviderSDKBase } from '@lido-sdk/react';
 import { useWeb3React, Web3ReactProvider } from '@web3-react/core';
 import { ReefKnot } from '@reef-knot/core-react';
 import { useAccount } from 'wagmi';
+import * as wagmiChains from 'wagmi/chains';
 import { SWRConfiguration } from 'swr';
 import { useWeb3 } from '../hooks/index';
 import { POLLING_INTERVAL } from '../constants';
@@ -119,14 +120,26 @@ const ProviderWeb3: FC<ProviderWeb3Props> = (props) => {
     appLogoUrl,
     ...sdkProps
   } = props;
-  const { defaultChainId } = props;
+  const { defaultChainId, supportedChainIds } = props;
   const connectorsProps = { rpc, appName, appLogoUrl, defaultChainId };
+  const wagmiChainsArray = Object.values(wagmiChains);
+  const supportedWagmiChains = wagmiChainsArray.filter((chain) =>
+    supportedChainIds.includes(chain.id),
+  );
+  const defaultWagmiChain = wagmiChainsArray.find(
+    (chain) => chain.id === defaultChainId,
+  );
 
   return (
     <Web3ReactProvider getLibrary={getLibrary}>
       <ProviderSDK rpc={rpc} {...sdkProps}>
         <ProviderConnectors {...connectorsProps}>
-          <ReefKnot rpc={rpc} walletconnectProjectId={walletconnectProjectId}>
+          <ReefKnot
+            rpc={rpc}
+            walletconnectProjectId={walletconnectProjectId}
+            chains={supportedWagmiChains}
+            defaultChain={defaultWagmiChain}
+          >
             {children}
           </ReefKnot>
         </ProviderConnectors>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,10 +1491,10 @@
     stream-browserify "^3.0.0"
     util "^0.12.4"
 
-"@coinbase/wallet-sdk@^3.6.4":
-  version "3.6.6"
-  resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-3.6.6.tgz#4a0758fe0fe0ba3ed7e33b5bb6eb094ff8bd6c98"
-  integrity sha512-vX+epj/Ttjo7XRwlr3TFUUfW5GTRMvORpERPwiu7z2jl3DSVL4rXLmHt5y6LDPlUVreas2gumdcFbu0fLRG9Jg==
+"@coinbase/wallet-sdk@^3.6.6":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz#44b3b7a925ff5cc974e4cbf7a44199ffdcf03541"
+  integrity sha512-LjyoDCB+7p0waQXfK+fUgcAs3Ezk6S6e+LYaoFjpJ6c9VTop3NyZF40Pi7df4z7QJohCwzuIDjz0Rhtig6Y7Pg==
   dependencies:
     "@metamask/safe-event-emitter" "2.0.0"
     "@solana/web3.js" "^1.70.1"
@@ -2491,10 +2491,10 @@
     "@motionone/utils" "^10.15.1"
     tslib "^2.3.1"
 
-"@motionone/dom@^10.15.5":
-  version "10.15.5"
-  resolved "https://registry.yarnpkg.com/@motionone/dom/-/dom-10.15.5.tgz#4af18f8136d85c2fc997cac98121c969f6731802"
-  integrity sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==
+"@motionone/dom@^10.16.2":
+  version "10.16.2"
+  resolved "https://registry.yarnpkg.com/@motionone/dom/-/dom-10.16.2.tgz#0c44df8ee3d1cfc50ee11d27050b27824355a61a"
+  integrity sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==
   dependencies:
     "@motionone/animation" "^10.15.1"
     "@motionone/generators" "^10.15.1"
@@ -2520,12 +2520,12 @@
     "@motionone/utils" "^10.15.1"
     tslib "^2.3.1"
 
-"@motionone/svelte@^10.15.5":
-  version "10.15.5"
-  resolved "https://registry.yarnpkg.com/@motionone/svelte/-/svelte-10.15.5.tgz#f36b40101ec1db122820598089f42e831f6cf5f5"
-  integrity sha512-Xyxtgp7BlVnSBwcoFmXGHUVnpNktzeXsEifu2NJJWc7VGuxutDsBZxNdz80qvpLIC5MeBa1wh7GGegZzTm1msg==
+"@motionone/svelte@^10.16.2":
+  version "10.16.2"
+  resolved "https://registry.yarnpkg.com/@motionone/svelte/-/svelte-10.16.2.tgz#0b37c3b12927814d31d24941d1ca0ff49981b444"
+  integrity sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==
   dependencies:
-    "@motionone/dom" "^10.15.5"
+    "@motionone/dom" "^10.16.2"
     tslib "^2.3.1"
 
 "@motionone/types@^10.15.1":
@@ -2542,12 +2542,12 @@
     hey-listen "^1.0.8"
     tslib "^2.3.1"
 
-"@motionone/vue@^10.15.5":
-  version "10.15.5"
-  resolved "https://registry.yarnpkg.com/@motionone/vue/-/vue-10.15.5.tgz#3101c62b2fce06b3f3072b9ff0f551213eb02476"
-  integrity sha512-cUENrLYAolUacHvCgU+8wF9OgSlVutfWbHMLERI/bElCJ+e2YVQvG/CpGhIM5fYOOJzuvg2T2wHmLLmvJoavEw==
+"@motionone/vue@^10.16.2":
+  version "10.16.2"
+  resolved "https://registry.yarnpkg.com/@motionone/vue/-/vue-10.16.2.tgz#faf13afc27620a2df870c71c58a04ee8de8dea65"
+  integrity sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==
   dependencies:
-    "@motionone/dom" "^10.15.5"
+    "@motionone/dom" "^10.16.2"
     tslib "^2.3.1"
 
 "@next/env@12.3.4":
@@ -3677,33 +3677,33 @@
     "@typescript-eslint/types" "5.42.0"
     eslint-visitor-keys "^3.3.0"
 
-"@wagmi/chains@0.2.19":
-  version "0.2.19"
-  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-0.2.19.tgz#d99febe8fb6bfa94fb8e27ebdbf21d58112f5c1f"
-  integrity sha512-pyqGjOscXH/ZFUJni+VpKmVIENz/vsgq2sgqpNAmLQ6h7/DYrzRvptij+b62K5wONZMr+7X2J5mHM9s4tkEd6A==
+"@wagmi/chains@0.2.22":
+  version "0.2.22"
+  resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-0.2.22.tgz#25e511e134a00742e4fbf5108613dadf876c5bd9"
+  integrity sha512-TdiOzJT6TO1JrztRNjTA5Quz+UmQlbvWFG8N41u9tta0boHA1JCAzGGvU6KuIcOmJfRJkKOUIt67wlbopCpVHg==
 
-"@wagmi/connectors@0.3.16":
-  version "0.3.16"
-  resolved "https://registry.yarnpkg.com/@wagmi/connectors/-/connectors-0.3.16.tgz#572fb221f6945aa42b2fbf7332d2f00f408471b2"
-  integrity sha512-WtiFyvai6IWbV7DhujjmtJF0m+FFQCiIDrtHsNf1xio0gBfpnO8rT9PZQQf0uxuLn0nLxqXqYMMwzPipUNaIcg==
+"@wagmi/connectors@0.3.21":
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/@wagmi/connectors/-/connectors-0.3.21.tgz#0bec726c14217ad391f6e49af1203ccf0249786e"
+  integrity sha512-yXtczgBQzVhUeo6D2L9yu8HmWQv08v6Ji5Cb4ZNL1mM2VVnvXxv7l40fSschcTw6H5jBZytgeGgL/aTYhn3HYQ==
   dependencies:
-    "@coinbase/wallet-sdk" "^3.6.4"
+    "@coinbase/wallet-sdk" "^3.6.6"
     "@ledgerhq/connect-kit-loader" "^1.0.1"
     "@safe-global/safe-apps-provider" "^0.15.2"
     "@safe-global/safe-apps-sdk" "^7.9.0"
-    "@walletconnect/ethereum-provider" "2.7.0"
+    "@walletconnect/ethereum-provider" "2.8.1"
     "@walletconnect/legacy-provider" "^2.0.0"
-    "@web3modal/standalone" "^2.3.0"
+    "@walletconnect/modal" "^2.4.6"
     abitype "^0.3.0"
     eventemitter3 "^4.0.7"
 
-"@wagmi/core@0.10.10":
-  version "0.10.10"
-  resolved "https://registry.yarnpkg.com/@wagmi/core/-/core-0.10.10.tgz#025299d484fb7de7980cad863c61ed6cfc481291"
-  integrity sha512-oghQIASk+QfrRku2m36NJTZnj5gpJNqfID5G3kZlBReWr01iOFbGfTVcS6Pcu2X3rsR2lmky8Tu5DWLXdKeGZg==
+"@wagmi/core@0.10.14":
+  version "0.10.14"
+  resolved "https://registry.yarnpkg.com/@wagmi/core/-/core-0.10.14.tgz#5b07df06c5d5a29bcee76b1ad71695e88559955b"
+  integrity sha512-+iQj5YNdVQ/kLVpVMLmF71Y2vnW3ox4b4Na4S9fvQazGudhqfqfpQ+YPYmH6SIIuZ1VhRnBmjJIY88IZt/OkwA==
   dependencies:
-    "@wagmi/chains" "0.2.19"
-    "@wagmi/connectors" "0.3.16"
+    "@wagmi/chains" "0.2.22"
+    "@wagmi/connectors" "0.3.21"
     abitype "^0.3.0"
     eventemitter3 "^4.0.7"
     zustand "^4.3.1"
@@ -3729,14 +3729,15 @@
     "@walletconnect/types" "^1.8.0"
     "@walletconnect/utils" "^1.8.0"
 
-"@walletconnect/core@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.7.0.tgz#26f19710958648e401968ab2fd427d6b07fb3b37"
-  integrity sha512-xUeFPpElybgn1a+lknqtHleei4VyuV/4qWgB1nP8qQUAO6a5pNsioODrnB2VAPdUHJYBdx2dCt2maRk6g53IPQ==
+"@walletconnect/core@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.8.1.tgz#f74404af372a11e05c214cbc14b5af0e9c0cf916"
+  integrity sha512-mN9Zkdl/NeThntK8cydDoQOW6jUEpOeFgYR1RCKPLH51VQwlbdSgvvQIeanSQXEY4U7AM3x8cs1sxqMomIfRQg==
   dependencies:
     "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-provider" "^1.0.12"
-    "@walletconnect/jsonrpc-utils" "^1.0.7"
+    "@walletconnect/jsonrpc-provider" "1.0.13"
+    "@walletconnect/jsonrpc-types" "1.0.3"
+    "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/jsonrpc-ws-connection" "^1.0.11"
     "@walletconnect/keyvaluestorage" "^1.0.2"
     "@walletconnect/logger" "^2.0.1"
@@ -3744,8 +3745,8 @@
     "@walletconnect/relay-auth" "^1.0.4"
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.7.0"
-    "@walletconnect/utils" "2.7.0"
+    "@walletconnect/types" "2.8.1"
+    "@walletconnect/utils" "2.8.1"
     events "^3.3.0"
     lodash.isequal "4.5.0"
     uint8arrays "^3.1.0"
@@ -3811,19 +3812,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/ethereum-provider@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.7.0.tgz#5aaf10ce8de9269904b7714428554f1a64b7932d"
-  integrity sha512-6TwQ05zi6DP1TP1XNgSvLbmCmLf/sz7kLTfMaVk45YYHNgYTTBlXqkyjUpQZI9lpq+uXLBbHn/jx2OGhOPUP0Q==
+"@walletconnect/ethereum-provider@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.8.1.tgz#1743072f42b5c940648b0303a382e8907a362a00"
+  integrity sha512-YlF8CCiFTSEZRyANIBsop/U+t+d1Z1/UXXoE9+iwjSGKJsaym6PgBLPb2d8XdmS/qR6Tcx7lVodTp4cVtezKnA==
   dependencies:
-    "@walletconnect/jsonrpc-http-connection" "^1.0.4"
-    "@walletconnect/jsonrpc-provider" "^1.0.11"
-    "@walletconnect/jsonrpc-types" "^1.0.2"
-    "@walletconnect/jsonrpc-utils" "^1.0.7"
-    "@walletconnect/sign-client" "2.7.0"
-    "@walletconnect/types" "2.7.0"
-    "@walletconnect/universal-provider" "2.7.0"
-    "@walletconnect/utils" "2.7.0"
+    "@walletconnect/jsonrpc-http-connection" "^1.0.7"
+    "@walletconnect/jsonrpc-provider" "^1.0.13"
+    "@walletconnect/jsonrpc-types" "^1.0.3"
+    "@walletconnect/jsonrpc-utils" "^1.0.8"
+    "@walletconnect/sign-client" "2.8.1"
+    "@walletconnect/types" "2.8.1"
+    "@walletconnect/universal-provider" "2.8.1"
+    "@walletconnect/utils" "2.8.1"
     events "^3.3.0"
 
 "@walletconnect/ethereum-provider@^1.7.1":
@@ -3885,12 +3886,22 @@
     cross-fetch "^3.1.4"
     tslib "1.14.1"
 
-"@walletconnect/jsonrpc-provider@^1.0.11", "@walletconnect/jsonrpc-provider@^1.0.12":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.12.tgz#965408d99fc889d49c194cd207804282805f45ed"
-  integrity sha512-6uI2y5281gloZSzICOjk+CVC7CVu0MhtMt2Yzpj05lPb0pzm/bK2oZ2ibxwLerPrqpNt/5bIFVRmoOgPw1mHAQ==
+"@walletconnect/jsonrpc-http-connection@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.7.tgz#a6973569b8854c22da707a759d241e4f5c2d5a98"
+  integrity sha512-qlfh8fCfu8LOM9JRR9KE0s0wxP6ZG9/Jom8M0qsoIQeKF3Ni0FyV4V1qy/cc7nfI46SLQLSl4tgWSfLiE1swyQ==
   dependencies:
-    "@walletconnect/jsonrpc-utils" "^1.0.7"
+    "@walletconnect/jsonrpc-utils" "^1.0.6"
+    "@walletconnect/safe-json" "^1.0.1"
+    cross-fetch "^3.1.4"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-provider@1.0.13", "@walletconnect/jsonrpc-provider@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz#9a74da648d015e1fffc745f0c7d629457f53648b"
+  integrity sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.8"
     "@walletconnect/safe-json" "^1.0.2"
     tslib "1.14.1"
 
@@ -3911,6 +3922,14 @@
     "@walletconnect/safe-json" "^1.0.1"
     tslib "1.14.1"
 
+"@walletconnect/jsonrpc-types@1.0.3", "@walletconnect/jsonrpc-types@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz#65e3b77046f1a7fa8347ae02bc1b841abe6f290c"
+  integrity sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==
+  dependencies:
+    keyvaluestorage-interface "^1.0.0"
+    tslib "1.14.1"
+
 "@walletconnect/jsonrpc-types@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.1.tgz#a96b4bb2bcc8838a70e06f15c1b5ab11c47d8e95"
@@ -3924,6 +3943,15 @@
   integrity sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==
   dependencies:
     keyvaluestorage-interface "^1.0.0"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-utils@1.0.8", "@walletconnect/jsonrpc-utils@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz#82d0cc6a5d6ff0ecc277cb35f71402c91ad48d72"
+  integrity sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==
+  dependencies:
+    "@walletconnect/environment" "^1.0.1"
+    "@walletconnect/jsonrpc-types" "^1.0.3"
     tslib "1.14.1"
 
 "@walletconnect/jsonrpc-utils@^1.0.3":
@@ -4044,6 +4072,14 @@
   resolved "https://registry.yarnpkg.com/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz#502cf8ab87330841d794819081e748ebdef7aee5"
   integrity sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==
 
+"@walletconnect/modal@^2.4.6":
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@walletconnect/modal/-/modal-2.4.7.tgz#fd84d6f1ac767865d63153e32150f790739a189a"
+  integrity sha512-kFpvDTT44CgNGcwQVC0jHrYed4xorghKX1DOGo8ZfBSJ5TJx3p6d6SzLxkH1cZupWbljWkYS6SqvZcUBs8vWpg==
+  dependencies:
+    "@web3modal/core" "2.4.7"
+    "@web3modal/ui" "2.4.7"
+
 "@walletconnect/qrcode-modal@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@walletconnect/qrcode-modal/-/qrcode-modal-1.8.0.tgz#ddd6f5c9b7ee52c16adf9aacec2a3eac4994caea"
@@ -4114,19 +4150,19 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/sign-client@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.7.0.tgz#c08c90a1fc95340d5d40d2cfd88f59d4d385a676"
-  integrity sha512-K99xa6GSFS04U+140yrIEi/VJJJ0Q1ov4jCaiqa9euILDKxlBsM7m5GR+9sq6oYyj18SluJY4CJTdeOXUJlarA==
+"@walletconnect/sign-client@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.8.1.tgz#8c6de724eff6a306c692dd66e66944089be5e30a"
+  integrity sha512-6DbpjP9BED2YZOZdpVgYo0HwPBV7k99imnsdMFrTn16EFAxhuYP0/qPwum9d072oNMGWJSA6d4rzc8FHNtHsCA==
   dependencies:
-    "@walletconnect/core" "2.7.0"
+    "@walletconnect/core" "2.8.1"
     "@walletconnect/events" "^1.0.1"
     "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-utils" "^1.0.7"
+    "@walletconnect/jsonrpc-utils" "1.0.8"
     "@walletconnect/logger" "^2.0.1"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.7.0"
-    "@walletconnect/utils" "2.7.0"
+    "@walletconnect/types" "2.8.1"
+    "@walletconnect/utils" "2.8.1"
     events "^3.3.0"
 
 "@walletconnect/signer-connection@^1.8.0":
@@ -4157,14 +4193,14 @@
   dependencies:
     tslib "1.14.1"
 
-"@walletconnect/types@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.7.0.tgz#af639c463d0d80d0fd03da80f2fc593c73a93ae9"
-  integrity sha512-aMUDUtO79WSBtC/bDetE6aFwdgwJr0tJ8nC8gnAl5ELsrjygEKCn6M8Q+v6nP9svG9yf5Rds4cImxCT6BWwTyw==
+"@walletconnect/types@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.8.1.tgz#640eb6ad23866886fbe09a9b29832bf3f8647a09"
+  integrity sha512-MLISp85b+27vVkm3Wkud+eYCwySXCdOrmn0yQCSN6DnRrrunrD05ksz4CXGP7h2oXUvvXPDt/6lXBf1B4AfqrA==
   dependencies:
     "@walletconnect/events" "^1.0.1"
     "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-types" "^1.0.2"
+    "@walletconnect/jsonrpc-types" "1.0.3"
     "@walletconnect/keyvaluestorage" "^1.0.2"
     "@walletconnect/logger" "^2.0.1"
     events "^3.3.0"
@@ -4174,41 +4210,40 @@
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-1.8.0.tgz#3f5e85b2d6b149337f727ab8a71b8471d8d9a195"
   integrity sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==
 
-"@walletconnect/universal-provider@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.7.0.tgz#4bb36b353d2c2d7c466e89e2d8c576727c4388d0"
-  integrity sha512-aAIudO3ZlKD16X36VnXChpxBB6/JLK1SCJBfidk7E0GE2S4xr1xW5jXGSGS4Z+wIkNZXK0n7ULSK3PZ7mPBdog==
+"@walletconnect/universal-provider@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.8.1.tgz#3fc51c56d1c94a02eb952f9bf948293cc7aace7e"
+  integrity sha512-6shgE4PM/S+GEh9oTWMloHZlt2BLsCitRn9tBh2Vf+jZiGlug3WNm+tBc/Fo6ILyHuzeYPbkzCM67AxcutOHGQ==
   dependencies:
-    "@walletconnect/jsonrpc-http-connection" "^1.0.4"
-    "@walletconnect/jsonrpc-provider" "^1.0.11"
+    "@walletconnect/jsonrpc-http-connection" "^1.0.7"
+    "@walletconnect/jsonrpc-provider" "1.0.13"
     "@walletconnect/jsonrpc-types" "^1.0.2"
     "@walletconnect/jsonrpc-utils" "^1.0.7"
     "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/sign-client" "2.7.0"
-    "@walletconnect/types" "2.7.0"
-    "@walletconnect/utils" "2.7.0"
+    "@walletconnect/sign-client" "2.8.1"
+    "@walletconnect/types" "2.8.1"
+    "@walletconnect/utils" "2.8.1"
     eip1193-provider "1.0.1"
     events "^3.3.0"
 
-"@walletconnect/utils@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.7.0.tgz#18482834b8a27e0515ef160a1ff7e4632c9d77f5"
-  integrity sha512-k32jrQeyJsNZPdmtmg85Y3QgaS5YfzYSPrAxRC2uUD1ts7rrI6P5GG2iXNs3AvWKOuCgsp/PqU8s7AC7CRUscw==
+"@walletconnect/utils@2.8.1":
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.8.1.tgz#1356f4bba7f8b6664fc5b61ce3497596c8d9d603"
+  integrity sha512-d6p9OX3v70m6ijp+j4qvqiQZQU1vbEHN48G8HqXasyro3Z+N8vtcB5/gV4pTYsbWgLSDtPHj49mzbWQ0LdIdTw==
   dependencies:
     "@stablelib/chacha20poly1305" "1.0.1"
     "@stablelib/hkdf" "1.0.1"
     "@stablelib/random" "^1.0.2"
     "@stablelib/sha256" "1.0.1"
     "@stablelib/x25519" "^1.0.3"
-    "@walletconnect/jsonrpc-utils" "^1.0.7"
     "@walletconnect/relay-api" "^1.0.9"
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.7.0"
+    "@walletconnect/types" "2.8.1"
     "@walletconnect/window-getters" "^1.0.1"
     "@walletconnect/window-metadata" "^1.0.1"
     detect-browser "5.3.0"
-    query-string "7.1.1"
+    query-string "7.1.3"
     uint8arrays "^3.1.0"
 
 "@walletconnect/utils@^1.8.0":
@@ -4303,30 +4338,22 @@
     "@web3-react/abstract-connector" "^6.0.7"
     "@web3-react/types" "^6.0.7"
 
-"@web3modal/core@2.3.7":
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.3.7.tgz#2c8863489695c3ed4b7b01e416e126cc5c8d18ad"
-  integrity sha512-ggl9+tkAzz43npj97iTj6p4oQYaklxADQyCKAX7AnMfglZg5bRseMDGnfmpvnjlDn8TI+DGGO6da3ITmYRIDYQ==
+"@web3modal/core@2.4.7":
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.4.7.tgz#e128be449bc5f6f23f6fb32f12021c096b5e7a07"
+  integrity sha512-FZMmI4JnEZovRDdN+PZBMe2ot8ly+UftVkZ6lmtfgiRZ2Gy3k/4IYE8/KwOSmN63Lf2Oj2077buLR17i0xoKZA==
   dependencies:
     buffer "6.0.3"
-    valtio "1.10.4"
+    valtio "1.10.5"
 
-"@web3modal/standalone@^2.3.0":
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/standalone/-/standalone-2.3.7.tgz#2536effb3a7c4b9384fa51c43dc67ff3caed0314"
-  integrity sha512-zgavWcimRVXnLdup2WQ0fFEnBnH+Wwn+k1/XzhwVpdJ//mrExWNYQaXt139RijxGUcux68ExRCyMqm1jkXTq3g==
+"@web3modal/ui@2.4.7":
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.4.7.tgz#94d70e60386eb6fae422c56386019e761f80a50a"
+  integrity sha512-5tU9u5CVYueZ9y+1x1A1Q0bFUfk3gOIKy3MT6Vx+aI0RDxVu7OYQDw6wbNPlgz/wd9JPYXG6uSv8WTBpdyit8Q==
   dependencies:
-    "@web3modal/core" "2.3.7"
-    "@web3modal/ui" "2.3.7"
-
-"@web3modal/ui@2.3.7":
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.3.7.tgz#0867ec4262a5a221418acdb571101d05628e8d62"
-  integrity sha512-mNDXY4ElcvXXixKHZTLcEjKC9zs3O8BD1EtaC8cKIy+RKFyHMpLB1DOQmz77tn91jNjOkrvEryqUwCbsJ7hjfA==
-  dependencies:
-    "@web3modal/core" "2.3.7"
-    lit "2.7.3"
-    motion "10.15.5"
+    "@web3modal/core" "2.4.7"
+    lit "2.7.5"
+    motion "10.16.2"
     qrcode "1.5.3"
 
 JSONStream@^1.3.5:
@@ -5453,7 +5480,7 @@ decimal.js@^10.4.2:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
   integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
-decode-uri-component@^0.2.0:
+decode-uri-component@^0.2.0, decode-uri-component@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
@@ -8098,10 +8125,10 @@ lit-html@^2.7.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit@2.7.3:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.7.3.tgz#7f7920dbaba12828d359ca3439cd6f73619061da"
-  integrity sha512-0a+u+vVbmgSfPu+fyvqjMPBX0Kwbyj9QOv9MbQFZhWGlV2cyk3lEwgfUQgYN+i/lx++1Z3wZknSIp3QCKxHLyg==
+lit@2.7.5:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.7.5.tgz#60bc82990cfad169d42cd786999356dcf79b035f"
+  integrity sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==
   dependencies:
     "@lit/reactive-element" "^1.6.0"
     lit-element "^3.3.0"
@@ -8351,17 +8378,17 @@ mixme@^0.5.1:
   resolved "https://registry.yarnpkg.com/mixme/-/mixme-0.5.4.tgz#8cb3bd0cd32a513c161bf1ca99d143f0bcf2eff3"
   integrity sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==
 
-motion@10.15.5:
-  version "10.15.5"
-  resolved "https://registry.yarnpkg.com/motion/-/motion-10.15.5.tgz#d336ddbdd37bc28bb99fbb243fe309df6c685ad6"
-  integrity sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==
+motion@10.16.2:
+  version "10.16.2"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-10.16.2.tgz#7dc173c6ad62210a7e9916caeeaf22c51e598d21"
+  integrity sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==
   dependencies:
     "@motionone/animation" "^10.15.1"
-    "@motionone/dom" "^10.15.5"
-    "@motionone/svelte" "^10.15.5"
+    "@motionone/dom" "^10.16.2"
+    "@motionone/svelte" "^10.16.2"
     "@motionone/types" "^10.15.1"
     "@motionone/utils" "^10.15.1"
-    "@motionone/vue" "^10.15.5"
+    "@motionone/vue" "^10.16.2"
 
 ms@2.0.0:
   version "2.0.0"
@@ -8944,10 +8971,10 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proxy-compare@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.5.0.tgz#0387c5e4d283ba9b1c0353bb20def4449b06bbd2"
-  integrity sha512-f1us0OsVAJ3tdIMXGQx2lmseYS4YXe4W+sKF5g5ww/jV+5ogMadPt+sIZ+88Ga9kvMJsrRNWzCrKPpr6pMWYbA==
+proxy-compare@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.5.1.tgz#17818e33d1653fbac8c2ec31406bce8a2966f600"
+  integrity sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -9013,12 +9040,12 @@ query-string@6.13.5:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-query-string@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
-  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+query-string@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
+  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
   dependencies:
-    decode-uri-component "^0.2.0"
+    decode-uri-component "^0.2.2"
     filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
@@ -10356,12 +10383,12 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-valtio@1.10.4:
-  version "1.10.4"
-  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.10.4.tgz#762647d102f14060111ed21e8afa28f424c2be78"
-  integrity sha512-gqGWh0DjtDMAy8Jaui8ufFoxlQB1k1NiA/QHrpKoTUk9EeY331WKeYhvtGn1u703RcefrDCez7PT+qeCu9lWEw==
+valtio@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.10.5.tgz#7852125e3b774b522827d96bd9c76d285c518678"
+  integrity sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==
   dependencies:
-    proxy-compare "2.5.0"
+    proxy-compare "2.5.1"
     use-sync-external-store "1.2.0"
 
 w3c-xmlserializer@^4.0.0:
@@ -10371,15 +10398,15 @@ w3c-xmlserializer@^4.0.0:
   dependencies:
     xml-name-validator "^4.0.0"
 
-wagmi@0.12.12, wagmi@^0.12.12:
-  version "0.12.12"
-  resolved "https://registry.yarnpkg.com/wagmi/-/wagmi-0.12.12.tgz#1b87a1aa5360e43cca4272313ea215b0b9c4066c"
-  integrity sha512-AEY4res9WCeAEbVv++tgdx6981lkdiAwfpLPj24mawMoocj2Cqr6j304lq7EJiEhnoiPqIwvbBzme3sAmUWYUA==
+wagmi@^0.12.16:
+  version "0.12.16"
+  resolved "https://registry.yarnpkg.com/wagmi/-/wagmi-0.12.16.tgz#4e5e2a29fd9d646b5a06e0ff8838be4d3459ed03"
+  integrity sha512-ZnQYC7wkcxNrfIZ+8LIYIXaEmnih8n4aUBZ5J+YI6QwnAWfo80jI79Z5F0BBML6wG7PYP2iIzMbIlnDIfx67uQ==
   dependencies:
     "@tanstack/query-sync-storage-persister" "^4.27.1"
     "@tanstack/react-query" "^4.28.0"
     "@tanstack/react-query-persist-client" "^4.28.0"
-    "@wagmi/core" "0.10.10"
+    "@wagmi/core" "0.10.14"
     abitype "^0.3.0"
     use-sync-external-store "^1.2.0"
 


### PR DESCRIPTION
### Changes
1. Explicitly pass changes to all wagmi connectors. Looks like this is the proper way (but not obvious) of configuration for wagmi, and it solves the issue when it is not possible to connect WalletConnect v2 to a testnet.
2. Update wagmi to v0.12.16, it updates `@walletconnect` libraries and brings latest fixes for WC