### PR TITLE
Move ledgerhq libraries into reef-knot

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "workspaces": [
     "apps/*",
     "packages/*",
-    "packages/wallets/*"
+    "packages/wallets/*",
+    "packages/connectors/*"
   ],
   "scripts": {
     "build": "turbo run build",

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.5.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/web3-react@1.3.0
+
 ## 1.4.3
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -45,7 +45,7 @@
     "@reef-knot/types": "^1.2.1",
     "@reef-knot/ui-react": "^1.0.4",
     "@reef-knot/wallets-icons": "^1.0.0",
-    "@reef-knot/web3-react": "^1.2.1",
+    "@reef-knot/web3-react": "^1.3.0",
     "@types/ua-parser-js": "^0.7.36",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -57,7 +57,7 @@
     "@reef-knot/types": "^1.2.1",
     "@reef-knot/ui-react": "^1.0.4",
     "@reef-knot/wallets-icons": "^1.0.0",
-    "@reef-knot/web3-react": "^1.2.1",
+    "@reef-knot/web3-react": "^1.3.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
     "wagmi": "^0.12.17"

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -47,7 +47,6 @@
     "@reef-knot/wallets-icons": "^1.0.0",
     "@reef-knot/web3-react": "^1.2.1",
     "@types/ua-parser-js": "^0.7.36",
-    "ethers": "^5.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "ua-parser-js": "1.0.33",

--- a/packages/connectors/ledger-connector/.eslintrc.json
+++ b/packages/connectors/ledger-connector/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "root": true,
+  "extends": [
+    "custom"
+  ],
+  "rules": {
+    "import/no-extraneous-dependencies": "warn"
+  }
+}

--- a/packages/connectors/ledger-connector/CHANGELOG.md
+++ b/packages/connectors/ledger-connector/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @reef-knot/ledger-connector
+
+## 1.0.0
+
+### Major Changes
+
+- Move ledger connectors to reef-knot

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ledger-connector",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@reef-knot/ledger-connector",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "dist/index.d.ts"
+      ]
+    }
+  },
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/lidofinance/reef-knot",
+  "bugs": {
+    "url": "https://github.com/lidofinance/reef-knot/issues"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "rollup -c",
+    "dev": "dev=on rollup -c -w",
+    "lint": "eslint"
+  },
+  "devDependencies": {
+    "@types/w3c-web-hid": "^1.0.2"
+  },
+  "dependencies": {
+    "@ethersproject/abstract-signer": "^5.5.0",
+    "@ethersproject/bignumber": "^5.5.0",
+    "@ethersproject/bytes": "^5.5.0",
+    "@ethersproject/properties": "^5.5.0",
+    "@ethersproject/providers": "^5.5.2",
+    "@ethersproject/strings": "^5.5.0",
+    "@ethersproject/transactions": "^5.5.0",
+    "@ledgerhq/hw-app-eth": "^6.33.1",
+    "@ledgerhq/hw-transport": "^6.28.2",
+    "@ledgerhq/hw-transport-webhid": "^6.27.13",
+    "@ledgerhq/iframe-provider": "0",
+    "@web3-react/abstract-connector": "^6.0.7",
+    "@web3-react/types": "^6.0.7",
+    "tiny-invariant": "^1.2.0"
+  }
+}

--- a/packages/connectors/ledger-connector/rollup.config.js
+++ b/packages/connectors/ledger-connector/rollup.config.js
@@ -1,0 +1,56 @@
+import * as process from 'node:process';
+import fs from 'node:fs';
+import ts from 'typescript';
+import { defineConfig } from 'rollup';
+import del from 'rollup-plugin-delete';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from 'rollup-plugin-typescript2';
+import { babel } from '@rollup/plugin-babel';
+import svgr from '@svgr/rollup';
+
+const extensions = ['.js', '.jsx', '.ts', '.tsx', '.svg'];
+const { dependencies = {}, peerDependencies = {} } =
+  JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+const commonExternal = [
+  'react/jsx-runtime',
+  // Do not include in the bundle subpath exports like:
+  /^@reef-knot\/.*/, // e.g. @reef-knot/<package>/<exports-field-entry>
+  /^reef-knot\/.*/, // e.g. reef-knot/wallets-icons/react
+];
+const external = [
+  ...commonExternal,
+  ...Object.keys({ ...dependencies, ...peerDependencies }),
+  /node_modules/
+];
+const isDevMode = process.env.dev === 'on';
+
+export default defineConfig({
+  input: './src/index',
+  output: {
+    format: 'es',
+    dir: 'dist',
+    preserveModules: true,
+    preserveModulesRoot: 'src',
+    generatedCode: 'es2015'
+  },
+  plugins: [
+    isDevMode ? null : del({ targets: 'dist/*', runOnce: true }),
+    resolve({ extensions, preferBuiltins: true }),
+    svgr({
+      typescript: true,
+      prettier: false,
+      memo: true,
+      svgo: false,
+    }),
+    typescript({
+      typescript: ts,
+      tsconfig: 'tsconfig.json',
+    }),
+    babel({
+      exclude: 'node_modules/**',
+      babelHelpers: 'bundled',
+      extensions,
+    }),
+  ],
+  external,
+});

--- a/packages/connectors/ledger-connector/src/README.md
+++ b/packages/connectors/ledger-connector/src/README.md
@@ -1,0 +1,51 @@
+# Ledger connectors
+
+## Ledger webhid connector
+
+Connector for [web3-react](https://github.com/NoahZinsmeister/web3-react) based on `@ledgerhq/hw-transport-webhid`
+
+## Arguments
+
+```ts
+new LedgerHQConnector({
+  chainId: number;
+  url: string;
+});
+```
+
+## Example
+
+```ts
+import { LedgerHQConnector } from '@reef-knot/ledger-connector';
+
+const LedgerHQFrame = new LedgerHQConnector({
+  chainId: 1,
+  url: 'https://your.rpc/endpoint',
+});
+```
+
+## Ledger iframe connector
+
+Connector for [web3-react](https://github.com/NoahZinsmeister/web3-react) based on `@ledgerhq/iframe-provider`
+
+## Arguments
+
+Connector has the same arguments as [IFrameEthereumProvider](https://github.com/LedgerHQ/iframe-provider#usage) as well an optional
+`supportedChainIds` to support testnets, defaults to Ethereum Mainnet only.
+
+```ts
+new LedgerHQFrameConnector({
+  targetOrigin?: string;
+  timeoutMilliseconds?: number;
+  supportedChainIds?: number[];
+});
+```
+
+## Example
+
+```ts
+import { LedgerHQFrameConnector } from '@reef-knot/ledger-connector';
+
+const LedgerHQFrame = new LedgerHQFrameConnector();
+```
+

--- a/packages/connectors/ledger-connector/src/hid/connector.ts
+++ b/packages/connectors/ledger-connector/src/hid/connector.ts
@@ -1,0 +1,80 @@
+import invariant from 'tiny-invariant';
+import { AbstractConnector } from '@web3-react/abstract-connector';
+import type { ConnectorUpdate } from '@web3-react/types';
+import { checkError, isHIDSupported } from './helpers';
+
+import type { LedgerHQProvider } from './provider';
+
+type LedgerHQConnectorArguments = {
+  chainId: number;
+  url: string;
+};
+
+export class LedgerHQConnector extends AbstractConnector {
+  public provider?: LedgerHQProvider;
+
+  public url: string;
+
+  public chainId: number;
+
+  constructor({ chainId, url }: LedgerHQConnectorArguments) {
+    super({ supportedChainIds: [chainId] });
+
+    this.chainId = chainId;
+    this.url = url;
+
+    this.handleDisconnect = this.handleDisconnect.bind(this);
+  }
+
+  private handleDisconnect(): void {
+    this.emitDeactivate();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public isSupported(): boolean {
+    return isHIDSupported();
+  }
+
+  public async getProviderInstance(): Promise<LedgerHQProvider> {
+    // eslint-disable-next-line no-shadow
+    const { LedgerHQProvider } = await import('./provider');
+    const Provider = new LedgerHQProvider(this.url, this.chainId);
+
+    return Provider;
+  }
+
+  public async activate(): Promise<ConnectorUpdate> {
+    try {
+      if (!this.provider) {
+        this.provider = await this.getProviderInstance();
+      }
+
+      this.provider.on('disconnect', this.handleDisconnect);
+      const account = await this.provider.enable();
+
+      return { provider: this.provider, account };
+    } catch (error) {
+      return checkError(error);
+    }
+  }
+
+  public async getProvider(): Promise<LedgerHQProvider | undefined> {
+    return this.provider;
+  }
+
+  public async getChainId(): Promise<number> {
+    return this.chainId;
+  }
+
+  public async getAccount(): Promise<string> {
+    invariant(this.provider, 'Provider is not defined');
+    return this.provider.getAddress();
+  }
+
+  public deactivate(): void {
+    invariant(this.provider, 'Provider is not defined');
+    this.provider.removeListener('disconnect', this.handleDisconnect);
+  }
+}
+
+export default LedgerHQConnector;

--- a/packages/connectors/ledger-connector/src/hid/connector.ts
+++ b/packages/connectors/ledger-connector/src/hid/connector.ts
@@ -38,9 +38,7 @@ export class LedgerHQConnector extends AbstractConnector {
   public async getProviderInstance(): Promise<LedgerHQProvider> {
     // eslint-disable-next-line no-shadow
     const { LedgerHQProvider } = await import('./provider');
-    const Provider = new LedgerHQProvider(this.url, this.chainId);
-
-    return Provider;
+    return new LedgerHQProvider(this.url, this.chainId);
   }
 
   public async activate(): Promise<ConnectorUpdate> {

--- a/packages/connectors/ledger-connector/src/hid/helpers.ts
+++ b/packages/connectors/ledger-connector/src/hid/helpers.ts
@@ -1,0 +1,84 @@
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
+import { resolveProperties } from '@ethersproject/properties';
+import { TransactionRequestExtended, UnsignedTransactionStrict } from './types';
+
+export const isHIDSupported = () => {
+  try {
+    return 'hid' in window.navigator;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const hasEIP1559 = (tx: {
+  type?: number;
+  maxFeePerGas?: BigNumberish;
+  maxPriorityFeePerGas?: BigNumberish;
+}) => {
+  return (
+    tx.type === 2 || tx.maxFeePerGas != null || tx.maxPriorityFeePerGas != null
+  );
+};
+
+export const toNumber = (
+  value: BigNumberish | undefined | null,
+): number | undefined => {
+  return value == null ? undefined : BigNumber.from(value).toNumber();
+};
+
+export const convertToUnsigned = async (
+  tx: TransactionRequestExtended,
+): Promise<UnsignedTransactionStrict> => {
+  const resolvedTx = await resolveProperties(tx);
+
+  const { chainId, data, gasLimit, gas, gasPrice, value, to } = resolvedTx;
+  const nonce = toNumber(resolvedTx.nonce);
+  const type = toNumber(resolvedTx.type);
+
+  // Allowed transaction keys for Legacy and EIP-155 Transactions
+  const baseTx: UnsignedTransactionStrict = {
+    gasLimit: gasLimit || gas,
+    type: type ?? 2,
+    chainId,
+    gasPrice,
+    nonce,
+    value,
+    data,
+    to,
+  };
+
+  // EIP-2930
+  if (tx.accessList != null) {
+    baseTx.accessList = tx.accessList;
+  }
+
+  // EIP-1559
+  if (hasEIP1559(tx)) {
+    baseTx.maxFeePerGas = tx.maxFeePerGas;
+    baseTx.maxPriorityFeePerGas = tx.maxPriorityFeePerGas;
+    baseTx.type = 2;
+  }
+
+  return baseTx;
+};
+
+export const checkError = (error: any): never => {
+  if (error.statusText === 'INS_NOT_SUPPORTED') {
+    // eslint-disable-next-line no-param-reassign
+    error.message =
+      'Device is not supported. Make sure the Ethereum app is open on the device.';
+  }
+
+  if (error.statusText === 'UNKNOWN_ERROR') {
+    // eslint-disable-next-line no-param-reassign
+    error.message =
+      'Unknown error. Make sure the device is connected and the Ethereum app is open on the device.';
+  }
+
+  if (error.statusText === 'CONDITIONS_OF_USE_NOT_SATISFIED') {
+    // eslint-disable-next-line no-param-reassign
+    error.message = 'User rejected the request';
+  }
+
+  throw error;
+};

--- a/packages/connectors/ledger-connector/src/hid/index.ts
+++ b/packages/connectors/ledger-connector/src/hid/index.ts
@@ -1,0 +1,1 @@
+export { LedgerHQConnector } from './connector';

--- a/packages/connectors/ledger-connector/src/hid/provider.ts
+++ b/packages/connectors/ledger-connector/src/hid/provider.ts
@@ -1,0 +1,106 @@
+import invariant from 'tiny-invariant';
+import { JsonRpcBatchProvider, Network } from '@ethersproject/providers';
+import type TransportHID from '@ledgerhq/hw-transport-webhid';
+import { LedgerHQSigner } from './signer';
+import { checkError, convertToUnsigned } from './helpers';
+
+import { TransactionRequestExtended } from './types';
+
+export class LedgerHQProvider extends JsonRpcBatchProvider {
+  public signer?: LedgerHQSigner;
+
+  public device?: HIDDevice;
+
+  public transport?: typeof TransportHID;
+
+  getSigner(): LedgerHQSigner {
+    return new LedgerHQSigner(this);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  listAccounts(): Promise<Array<string>> {
+    throw new Error('method is not implemented');
+  }
+
+  async detectNetwork(): Promise<Network> {
+    return this._network;
+  }
+
+  async getTransport(): Promise<TransportHID> {
+    invariant(this.transport, 'Transport is not defined');
+
+    try {
+      const transport = (await this.transport?.create()) as TransportHID;
+      this.device = transport.device;
+
+      return transport;
+    } catch (error) {
+      return checkError(error);
+    }
+  }
+
+  async enable(): Promise<string> {
+    try {
+      // eslint-disable-next-line no-shadow
+      const { default: TransportHID } = await import(
+        '@ledgerhq/hw-transport-webhid'
+      );
+      this.transport = TransportHID;
+
+      const { hid } = window.navigator;
+
+      const onDisconnect = (event: HIDConnectionEvent) => {
+        if (this.device === event.device) {
+          hid.removeEventListener('disconnect', onDisconnect);
+          this.emit('disconnect');
+        }
+      };
+
+      hid.addEventListener('disconnect', onDisconnect);
+
+      if (!this.signer) {
+        this.signer = this.getSigner();
+      }
+
+      return await this.getAddress();
+    } catch (error) {
+      return checkError(error);
+    }
+  }
+
+  async getAddress(): Promise<string> {
+    invariant(this.signer, 'Signer is not defined');
+    return await this.signer.getAddress();
+  }
+
+  async request({
+    method,
+    params,
+  }: {
+    method: string;
+    params: Array<unknown>;
+  }): Promise<unknown> {
+    invariant(this.signer, 'Signer is not defined');
+    switch (method) {
+      case 'eth_sendTransaction':
+        const sourceTx = params[0] as TransactionRequestExtended;
+        const unsignedTx = await convertToUnsigned(sourceTx);
+        const signedTx = await this.signer.signTransaction(unsignedTx);
+        return this.send('eth_sendRawTransaction', [signedTx]);
+      case 'eth_accounts':
+        return [await this.getAddress()];
+      case 'eth_signTypedData_v4':
+        if (typeof params[1] !== 'string')
+          throw new Error('eth_signTypedData_v4 arg 1 is not a string');
+        const payload = JSON.parse(params[1] as string);
+        return await this.signer.__signEIP712Message({
+          domain: payload.domain,
+          types: payload.types,
+          primaryType: payload.primaryType,
+          message: payload.message,
+        });
+      default:
+        return this.send(method, params);
+    }
+  }
+}

--- a/packages/connectors/ledger-connector/src/hid/signer.ts
+++ b/packages/connectors/ledger-connector/src/hid/signer.ts
@@ -1,0 +1,197 @@
+import Eth from '@ledgerhq/hw-app-eth';
+import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
+import {
+  LoadConfig,
+  ResolutionConfig,
+} from '@ledgerhq/hw-app-eth/lib/services/types';
+import {
+  EIP712MessageTypes,
+  EIP712Message,
+} from '@ledgerhq/hw-app-eth/lib/modules/EIP712/EIP712.types';
+import { JsonRpcSigner, TransactionRequest } from '@ethersproject/providers';
+import { BigNumber } from '@ethersproject/bignumber';
+import {
+  Signer,
+  TypedDataDomain,
+  TypedDataField,
+  TypedDataSigner,
+} from '@ethersproject/abstract-signer';
+import { UnsignedTransaction, serialize } from '@ethersproject/transactions';
+import { toUtf8Bytes } from '@ethersproject/strings';
+import { Bytes, hexlify, joinSignature } from '@ethersproject/bytes';
+import { _TypedDataEncoder } from '@ethersproject/hash';
+
+import { LedgerHQProvider } from './provider';
+import { checkError, convertToUnsigned, toNumber } from './helpers';
+import { UnsignedTransactionStrict } from './types';
+
+const defaultPath = "m/44'/60'/0'/0/0";
+
+export class LedgerHQSigner extends Signer implements TypedDataSigner {
+  readonly path: string;
+
+  readonly provider: LedgerHQProvider;
+
+  _index = 0;
+
+  _address = '';
+
+  constructor(provider: LedgerHQProvider, path: string = defaultPath) {
+    super();
+
+    this.path = path;
+    this.provider = provider;
+  }
+
+  async withEthApp<T>(callback: (eth: Eth) => T): Promise<T> {
+    const transport = await this.provider.getTransport();
+
+    try {
+      const eth = new Eth(transport);
+      await eth.getAppConfiguration();
+
+      return await callback(eth);
+    } catch (error) {
+      return checkError(error);
+    } finally {
+      await transport.close();
+    }
+  }
+
+  async getAddress(): Promise<string> {
+    if (!this._address) {
+      const account = await this.withEthApp((eth) => eth.getAddress(this.path));
+
+      const address = this.provider.formatter.address(account.address);
+      this._address = address;
+    }
+
+    return this._address;
+  }
+
+  async signMessage(message: Bytes | string): Promise<string> {
+    if (typeof message === 'string') {
+      // eslint-disable-next-line no-param-reassign
+      message = toUtf8Bytes(message);
+    }
+
+    const messageHex = hexlify(message).substring(2);
+    const sig = await this.withEthApp((eth) =>
+      eth.signPersonalMessage(this.path, messageHex),
+    );
+
+    sig.r = `0x${sig.r}`;
+    sig.s = `0x${sig.s}`;
+
+    return joinSignature(sig);
+  }
+
+  async populateUnsigned(
+    transaction: UnsignedTransactionStrict,
+  ): Promise<UnsignedTransaction> {
+    const populated = await this.populateTransaction(transaction);
+    const nonce = toNumber(populated.nonce);
+
+    if (populated.type === 0) {
+      const { gasLimit, type, chainId, gasPrice, value, data, to } = populated;
+
+      // Allowed transaction keys for Legacy and EIP-155 Transactions
+      return { gasLimit, type, chainId, gasPrice, nonce, value, data, to };
+    }
+
+    return { ...populated, nonce };
+  }
+
+  async signTransaction(
+    transaction: TransactionRequest,
+    loadConfig: LoadConfig = {},
+    resolutionConfig: ResolutionConfig = {},
+  ): Promise<string> {
+    const unsignedTx = await convertToUnsigned(transaction);
+    const populatedTx = await this.populateUnsigned(unsignedTx);
+
+    const serializedTx = serialize(populatedTx).substring(2);
+    const resolution = await ledgerService.resolveTransaction(
+      serializedTx,
+      loadConfig,
+      resolutionConfig,
+    );
+
+    const sig = await this.withEthApp((eth) =>
+      eth.signTransaction(this.path, serializedTx, resolution),
+    );
+
+    return serialize(populatedTx, {
+      v: BigNumber.from(`0x${sig.v}`).toNumber(),
+      r: `0x${sig.r}`,
+      s: `0x${sig.s}`,
+    });
+  }
+
+  connect(provider: LedgerHQProvider): JsonRpcSigner {
+    return new LedgerHQSigner(provider, this.path);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  connectUnchecked(): JsonRpcSigner {
+    throw new Error('method is not implemented');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  sendUncheckedTransaction(): Promise<string> {
+    throw new Error('method is not implemented');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async unlock(): Promise<boolean> {
+    throw new Error('method is not implemented');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async _legacySignMessage(message: Bytes | string): Promise<string> {
+    throw new Error('method is not implemented');
+  }
+
+  // _signTypedData as per ethers Signer, cleans up types, replaces domain, calculates primaryType
+  async _signTypedData(
+    domain: TypedDataDomain,
+    _types: Record<string, Array<TypedDataField>>,
+    value: Record<string, any>,
+  ): Promise<string> {
+    const types = { ..._types };
+    delete types.EIP712Domain;
+    const encoder = new _TypedDataEncoder(types);
+    const data: EIP712Message = {
+      domain: {
+        name: domain.name,
+        verifyingContract: domain.verifyingContract,
+        version: domain.version,
+        chainId: domain.chainId // eslint-disable-next-line radix
+          ? parseInt(domain.chainId.toString())
+          : undefined,
+      },
+      types: {
+        ...types,
+        EIP712Domain: [
+          { name: 'name', type: 'string' },
+          { name: 'version', type: 'string' },
+          { name: 'chainId', type: 'uint256' },
+          { name: 'verifyingContract', type: 'address' },
+        ],
+      } as EIP712MessageTypes,
+      primaryType: encoder.primaryType,
+      message: value,
+    };
+
+    return this.__signEIP712Message(data);
+  }
+
+  // custom method, also called directly on eth_signTypedData_v4 RPC request
+  async __signEIP712Message(data: EIP712Message): Promise<string> {
+    const { r, s, v } = await this.withEthApp((eth) =>
+      eth.signEIP712Message(this.path, data),
+    );
+
+    return joinSignature({ r: `0x${r}`, s: `0x${s}`, v });
+  }
+}

--- a/packages/connectors/ledger-connector/src/hid/types.ts
+++ b/packages/connectors/ledger-connector/src/hid/types.ts
@@ -1,0 +1,11 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+import { TransactionRequest } from '@ethersproject/providers';
+import { UnsignedTransaction } from '@ethersproject/transactions';
+
+export type UnsignedTransactionStrict = Omit<UnsignedTransaction, 'type'> & {
+  type?: number;
+};
+
+export type TransactionRequestExtended = TransactionRequest & {
+  gas?: BigNumberish;
+};

--- a/packages/connectors/ledger-connector/src/iframe/connector.ts
+++ b/packages/connectors/ledger-connector/src/iframe/connector.ts
@@ -1,0 +1,105 @@
+import invariant from 'tiny-invariant';
+import { AbstractConnector } from '@web3-react/abstract-connector';
+
+import type { ConnectorUpdate } from '@web3-react/types';
+import type { IFrameEthereumProvider } from '@ledgerhq/iframe-provider';
+import { isLedgerDappBrowserProvider } from './helpers';
+
+type IFrameEthereumProviderOptions = ConstructorParameters<
+  typeof IFrameEthereumProvider
+>[0] & { supportedChainIds?: number[] };
+
+const MAINNET_CHAIN_ID = 1;
+
+export class LedgerHQFrameConnector extends AbstractConnector {
+  private config: IFrameEthereumProviderOptions;
+
+  public provider?: IFrameEthereumProvider;
+
+  constructor(config?: IFrameEthereumProviderOptions) {
+    super({
+      supportedChainIds: config?.supportedChainIds ?? [MAINNET_CHAIN_ID],
+    });
+
+    this.config = config ?? {};
+
+    this.handleNetworkChanged = this.handleNetworkChanged.bind(this);
+    this.handleChainChanged = this.handleChainChanged.bind(this);
+    this.handleAccountsChanged = this.handleAccountsChanged.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  private handleNetworkChanged(networkId: string): void {
+    this.emitUpdate({ provider: this.provider, chainId: networkId });
+  }
+
+  private handleChainChanged(chainId: string): void {
+    this.emitUpdate({ chainId });
+  }
+
+  private handleAccountsChanged(accounts: string[]): void {
+    this.emitUpdate({ account: accounts.length === 0 ? null : accounts[0] });
+  }
+
+  private handleClose(): void {
+    this.emitDeactivate();
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public isLedgerApp(): boolean {
+    return isLedgerDappBrowserProvider();
+  }
+
+  public async getProviderInstance(): Promise<IFrameEthereumProvider> {
+    if (this.provider) return this.provider;
+
+    // eslint-disable-next-line no-shadow
+    const { IFrameEthereumProvider } = await import(
+      '@ledgerhq/iframe-provider'
+    );
+    return new IFrameEthereumProvider(this.config);
+  }
+
+  public async activate(): Promise<ConnectorUpdate> {
+    if (!this.provider) {
+      this.provider = await this.getProviderInstance();
+    }
+
+    this.provider.on('networkChanged', this.handleNetworkChanged);
+    this.provider.on('chainChanged', this.handleChainChanged);
+    this.provider.on('accountsChanged', this.handleAccountsChanged);
+    this.provider.on('close', this.handleClose);
+
+    const accounts = await this.provider.enable();
+    const account = accounts[0];
+
+    return { provider: this.provider, account };
+  }
+
+  public async getProvider(): Promise<IFrameEthereumProvider | undefined> {
+    return this.provider;
+  }
+
+  public async getChainId(): Promise<number | string> {
+    invariant(this.provider, 'Provider is not defined');
+    return this.provider.send('eth_chainId');
+  }
+
+  public async getAccount(): Promise<null | string> {
+    invariant(this.provider, 'Provider is not defined');
+
+    const accounts = await this.provider.send('eth_accounts');
+    const account = accounts[0];
+
+    return account;
+  }
+
+  public deactivate(): void {
+    invariant(this.provider, 'Provider is not defined');
+
+    this.provider.removeListener('networkChanged', this.handleNetworkChanged);
+    this.provider.removeListener('chainChanged', this.handleChainChanged);
+    this.provider.removeListener('accountsChanged', this.handleAccountsChanged);
+    this.provider.removeListener('close', this.handleClose);
+  }
+}

--- a/packages/connectors/ledger-connector/src/iframe/helpers.ts
+++ b/packages/connectors/ledger-connector/src/iframe/helpers.ts
@@ -1,0 +1,26 @@
+export const isIframe = (): boolean => {
+  try {
+    return window.self !== window.top;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const isLedgerDappBrowserProvider = (() => {
+  let state: boolean | null = null;
+
+  return (): boolean => {
+    if (typeof state === 'boolean') return state;
+    if (typeof window === 'undefined') return false;
+
+    try {
+      const params = new URLSearchParams(window.self.location.search);
+      const isEmbed = !!params.get('embed');
+
+      state = isIframe() && isEmbed;
+    } catch (error) {
+      state = false;
+    }
+    return state;
+  };
+})();

--- a/packages/connectors/ledger-connector/src/iframe/index.ts
+++ b/packages/connectors/ledger-connector/src/iframe/index.ts
@@ -1,0 +1,2 @@
+export * from './connector';
+export * from './helpers';

--- a/packages/connectors/ledger-connector/src/index.ts
+++ b/packages/connectors/ledger-connector/src/index.ts
@@ -1,0 +1,2 @@
+export { LedgerHQConnector } from './hid';
+export * from './iframe';

--- a/packages/connectors/ledger-connector/tsconfig.json
+++ b/packages/connectors/ledger-connector/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "tsconfig/react-library.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "compilerOptions": {
+    "rootDir": "src",
+  }
+}

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,15 @@
 # reef-knot
 
+## 1.5.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @reef-knot/web3-react@1.3.0
+  - @reef-knot/ledger-connector@1.0.0
+  - @reef-knot/connect-wallet-modal@1.5.0
+
 ## 1.4.5
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -48,6 +48,7 @@
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/wallets-list": "1.4.2",
     "@reef-knot/wallets-helpers": "1.1.2",
-    "@reef-knot/types": "1.2.1"
+    "@reef-knot/types": "1.2.1",
+    "@reef-knot/ledger-connector": "0.0.0"
   }
 }

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,14 +41,14 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.4.3",
+    "@reef-knot/connect-wallet-modal": "1.5.0",
     "@reef-knot/core-react": "1.4.2",
-    "@reef-knot/web3-react": "1.2.2",
+    "@reef-knot/web3-react": "1.3.0",
     "@reef-knot/ui-react": "1.0.5",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/wallets-list": "1.4.2",
     "@reef-knot/wallets-helpers": "1.1.2",
     "@reef-knot/types": "1.2.1",
-    "@reef-knot/ledger-connector": "0.0.0"
+    "@reef-knot/ledger-connector": "1.0.0"
   }
 }

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @reef-knot/web3-react
 
+## 1.3.0
+
+### Minor Changes
+
+- Use ledger connectors from reef-knot, pass supportedChainsId in LedgerHQFrameConnector
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/ledger-connector@1.0.0
+
 ## 1.2.2
 
 ### Patch Changes

--- a/packages/web3-react/README.md
+++ b/packages/web3-react/README.md
@@ -1,13 +1,6 @@
 # Web3 react helpers
 
 Web3 react helpers for Lido Finance projects.
-Part of [Lido JS SDK](https://github.com/lidofinance/lido-js-sdk/#readme)
-
-## Install
-
-```bash
-yarn add @lido-sdk/web3-react
-```
 
 ## Provider
 
@@ -36,18 +29,6 @@ const Provider = () => {
   );
 };
 ```
-
-## Connectors
-
-The `ProviderWeb3` creates several connectors and stores them in context. To access them directly use `useConnectors` hook.
-
-Used connectors:
-
-- [InjectedConnector](https://www.npmjs.com/package/@web3-react/injected-connector)
-- [WalletConnectConnector](https://www.npmjs.com/package/@web3-react/walletconnect-connector)
-- [WalletLinkConnector](https://www.npmjs.com/package/@web3-react/walletlink-connector)
-- [SafeAppConnector](https://www.npmjs.com/package/@gnosis.pm/safe-apps-web3-react)
-- [LedgerHQConnector](https://www.npmjs.com/package/web3-ledgerhq-connector)
 
 ## Auto connect
 

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -47,6 +47,7 @@
     "@babel/preset-typescript": "7.18.6",
     "@ethersproject/providers": "^5.7.2",
     "@reef-knot/core-react": "^1.4.1",
+    "@reef-knot/ledger-connector": "^0.0.0",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^29.4.0",
@@ -72,13 +73,12 @@
     "@web3-react/walletlink-connector": "6.2.14",
     "swr": "1.3.0",
     "tiny-invariant": "^1.1.0",
-    "tiny-warning": "^1.0.3",
-    "web3-ledgerhq-connector": "^1.2.3",
-    "web3-ledgerhq-frame-connector": "^1.0.1"
+    "tiny-warning": "^1.0.3"
   },
   "peerDependencies": {
     "@ethersproject/providers": "5",
     "@reef-knot/core-react": "^1.4.1",
+    "@reef-knot/ledger-connector": "^0.0.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
     "wagmi": "^0.12.17"

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -47,7 +47,7 @@
     "@babel/preset-typescript": "7.18.6",
     "@ethersproject/providers": "^5.7.2",
     "@reef-knot/core-react": "^1.4.1",
-    "@reef-knot/ledger-connector": "^0.0.0",
+    "@reef-knot/ledger-connector": "^1.0.0",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^29.4.0",
@@ -78,7 +78,7 @@
   "peerDependencies": {
     "@ethersproject/providers": "5",
     "@reef-knot/core-react": "^1.4.1",
-    "@reef-knot/ledger-connector": "^0.0.0",
+    "@reef-knot/ledger-connector": "^1.0.0",
     "react": ">=17",
     "ua-parser-js": "^1.0.33",
     "wagmi": "^0.12.17"

--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -4,8 +4,10 @@ import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { CHAINS } from '@lido-sdk/constants';
 import { useSDK } from '@lido-sdk/react';
-import { LedgerHQFrameConnector } from 'web3-ledgerhq-frame-connector';
-import { LedgerHQConnector } from 'web3-ledgerhq-connector';
+import {
+  LedgerHQConnector,
+  LedgerHQFrameConnector,
+} from '@reef-knot/ledger-connector';
 import { useAutoConnect } from '../hooks/useAutoConnect';
 import { CONNECTOR_NAMES } from '../constants';
 

--- a/packages/web3-react/src/context/connectors.tsx
+++ b/packages/web3-react/src/context/connectors.tsx
@@ -60,7 +60,9 @@ const ProviderConnectors: FC<ConnectorsContextProps> = (props) => {
         }
       })(),
 
-      [CONNECTOR_NAMES.LEDGER_HQ_LIVE]: new LedgerHQFrameConnector(),
+      [CONNECTOR_NAMES.LEDGER_HQ_LIVE]: new LedgerHQFrameConnector({
+        supportedChainIds,
+      }),
 
       [CONNECTOR_NAMES.LEDGER]: new LedgerHQConnector({
         chainId: defaultChainId,

--- a/packages/web3-react/src/hooks/useConnectorInfo.ts
+++ b/packages/web3-react/src/hooks/useConnectorInfo.ts
@@ -2,8 +2,10 @@ import { useAccount } from 'wagmi';
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { InjectedConnector } from '@web3-react/injected-connector';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
-import { LedgerHQFrameConnector } from 'web3-ledgerhq-frame-connector';
-import { LedgerHQConnector } from 'web3-ledgerhq-connector';
+import {
+  LedgerHQConnector,
+  LedgerHQFrameConnector,
+} from '@reef-knot/ledger-connector';
 import { useWeb3 } from './useWeb3';
 import { PROVIDER_NAMES } from '../constants';
 import {

--- a/packages/web3-react/src/hooks/useConnectorLedger.ts
+++ b/packages/web3-react/src/hooks/useConnectorLedger.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { LedgerHQConnector } from 'web3-ledgerhq-connector';
+import { LedgerHQConnector } from '@reef-knot/ledger-connector';
 import { useConnectors } from './useConnectors';
 import { useForceDisconnect } from './useDisconnect';
 import { useWeb3 } from './useWeb3';

--- a/packages/web3-react/test/hooks/useConnectorInfo.test.ts
+++ b/packages/web3-react/test/hooks/useConnectorInfo.test.ts
@@ -2,12 +2,10 @@ jest.mock('../../src/hooks/useWeb3');
 jest.mock('wagmi');
 
 import { renderHook } from '@testing-library/react-hooks';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
 import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react';
 import { WalletLinkConnector } from '@web3-react/walletlink-connector';
 import { InjectedConnector } from '@web3-react/injected-connector';
-import { LedgerHQFrameConnector } from 'web3-ledgerhq-frame-connector';
-import { LedgerHQConnector } from 'web3-ledgerhq-connector';
+import { LedgerHQConnector, LedgerHQFrameConnector } from '@reef-knot/ledger-connector';
 import { useConnectorInfo } from '../../src/hooks/useConnectorInfo';
 import { useWeb3 } from '../../src/hooks/useWeb3';
 import { useAccount } from 'wagmi';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,6 +1956,13 @@
   dependencies:
     invariant "2"
 
+"@ledgerhq/cryptoassets@^9.8.0":
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-9.8.0.tgz#e0b3470ea6bb6a0ea22a4e2abb81b9602a877e0f"
+  integrity sha512-0ryUC3u50CYXN4bQFMjlXXgID7+v1u/t/rDvmtRETKRxM9zEUDI8bULF5nGyCPR/a4z+I4WAe+GbSzbsGsWAhA==
+  dependencies:
+    invariant "2"
+
 "@ledgerhq/devices@^7.0.3":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-7.0.3.tgz#bdd7e8ce078399fe644067a7e1ca9a9d2e249c02"
@@ -1966,10 +1973,39 @@
     rxjs "6"
     semver "^7.3.5"
 
+"@ledgerhq/devices@^8.0.4":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-8.0.4.tgz#ebc7779adbbec2d046424603a481623eb3fbe306"
+  integrity sha512-dxOiWZmtEv1tgw70+rW8gviCRZUeGDUnxY6HUPiRqTAc0Ts2AXxiJChgAsPvIywWTGW+S67Nxq1oTZdpRbdt+A==
+  dependencies:
+    "@ledgerhq/errors" "^6.12.7"
+    "@ledgerhq/logs" "^6.10.1"
+    rxjs "6"
+    semver "^7.3.5"
+
+"@ledgerhq/domain-service@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/domain-service/-/domain-service-1.1.4.tgz#305fe076f6d206d56bb2cc107ef900f02b6c8879"
+  integrity sha512-jKnKqm/rqyAcDBgI/ZYom9kFDsBQkodxy6E14IEUJ5N8OkbPdHmjRfzn973nc5mTFJIafaifx0Arde0sjrBP9g==
+  dependencies:
+    "@ledgerhq/cryptoassets" "^9.8.0"
+    "@ledgerhq/errors" "^6.12.6"
+    "@ledgerhq/logs" "^6.10.1"
+    "@ledgerhq/types-live" "^6.35.1"
+    axios "^1.3.4"
+    eip55 "^2.1.0"
+    react "^17.0.2"
+    react-dom "^17.0.2"
+
 "@ledgerhq/errors@^6.11.1":
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.11.1.tgz#a8a81bda6d28ac43c757e109b1ff079ddeec54a6"
   integrity sha512-HT1PFvNrejcN5z3ba6xikacIdHWMkjBeE9U5FFoGHhaKBKGjC74mnCeEo0/oJunyuVId+9mhGnv6lrBl6Mkqdg==
+
+"@ledgerhq/errors@^6.12.6", "@ledgerhq/errors@^6.12.7":
+  version "6.12.7"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.12.7.tgz#c7b630488d5713bc7b1e1682d6ab5d08918c69f1"
+  integrity sha512-1BpjzFErPK7qPFx0oItcX0mNLJMplVAm2Dpl5urZlubewnTyyw5sahIBjU+8LLCWJ2eGEh/0wyvh0jMtR0n2Mg==
 
 "@ledgerhq/hw-app-eth@^6.22.3":
   version "6.29.10"
@@ -1985,6 +2021,31 @@
     "@ledgerhq/logs" "^6.10.1"
     axios "^0.26.1"
     bignumber.js "^9.0.2"
+
+"@ledgerhq/hw-app-eth@^6.33.1":
+  version "6.33.6"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-6.33.6.tgz#c9893ec5262952ced6d2fddfa12a87f2ccba61cc"
+  integrity sha512-QzYvr5FNEWWd70Vg04A2i8CY0mtPgJrrX7/KePabjXrR8NjDyJ5Ej8qSQPBTp2dkR4TGiz5Y7+HIcWpdgYzjzg==
+  dependencies:
+    "@ethersproject/abi" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ledgerhq/cryptoassets" "^9.8.0"
+    "@ledgerhq/domain-service" "^1.1.4"
+    "@ledgerhq/errors" "^6.12.6"
+    "@ledgerhq/hw-transport" "^6.28.4"
+    "@ledgerhq/hw-transport-mocker" "^6.27.15"
+    "@ledgerhq/logs" "^6.10.1"
+    axios "^1.3.4"
+    bignumber.js "^9.1.0"
+    crypto-js "^4.1.1"
+
+"@ledgerhq/hw-transport-mocker@^6.27.15":
+  version "6.27.16"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-6.27.16.tgz#f3fc9a3f5a06de4d4163d39d57150d08279c00c0"
+  integrity sha512-Il5ilAULsNSE5Wa8qG+Da+LcK61czU1pq8wrRjSd6rLbK0zLPOF2mUgMW1iwMgkdICGFLA0KUz2wouoVjQPqaw==
+  dependencies:
+    "@ledgerhq/hw-transport" "^6.28.5"
+    "@ledgerhq/logs" "^6.10.1"
 
 "@ledgerhq/hw-transport-mocker@^6.27.6":
   version "6.27.6"
@@ -2004,6 +2065,16 @@
     "@ledgerhq/hw-transport" "^6.27.6"
     "@ledgerhq/logs" "^6.10.1"
 
+"@ledgerhq/hw-transport-webhid@^6.27.13":
+  version "6.27.16"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.16.tgz#c8bb9f9a55d637134f24d51c2cef6e4aea3830ce"
+  integrity sha512-inNn710l01c0OI5sXo+8jNaxxGZermOdEsbF/a20pfvqFYvdz7WQAtmjO2NjUbScyFadxNmNnocQxQ5DRvMKOQ==
+  dependencies:
+    "@ledgerhq/devices" "^8.0.4"
+    "@ledgerhq/errors" "^6.12.7"
+    "@ledgerhq/hw-transport" "^6.28.5"
+    "@ledgerhq/logs" "^6.10.1"
+
 "@ledgerhq/hw-transport@^6.20.0", "@ledgerhq/hw-transport@^6.27.6":
   version "6.27.6"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-6.27.6.tgz#87f886591bad047c18e76920519aceb9d844667b"
@@ -2011,6 +2082,15 @@
   dependencies:
     "@ledgerhq/devices" "^7.0.3"
     "@ledgerhq/errors" "^6.11.1"
+    events "^3.3.0"
+
+"@ledgerhq/hw-transport@^6.28.2", "@ledgerhq/hw-transport@^6.28.4", "@ledgerhq/hw-transport@^6.28.5":
+  version "6.28.5"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-6.28.5.tgz#675193be2f695a596068145351da598316c25831"
+  integrity sha512-xmw5RhYbqExBBqTvOnOjN/RYNIGMBxFJ+zcYNfkfw/E+uEY3L7xq8Z7sC/n7URTT6xtEctElqduBJnBQE4OQtw==
+  dependencies:
+    "@ledgerhq/devices" "^8.0.4"
+    "@ledgerhq/errors" "^6.12.7"
     events "^3.3.0"
 
 "@ledgerhq/iframe-provider@0", "@ledgerhq/iframe-provider@0.4.2":
@@ -2024,6 +2104,14 @@
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.10.1.tgz#5bd16082261d7364eabb511c788f00937dac588d"
   integrity sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w==
+
+"@ledgerhq/types-live@^6.35.1":
+  version "6.35.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/types-live/-/types-live-6.35.1.tgz#90ad68ef1514641a04ea7c14d524a2a2d60ef004"
+  integrity sha512-p9xFAV7xKcrUZDO8C0geGPW1CXAWqWogbDrVG8PnCZfmcmH+AVwzHoUcKMi9SzmV3iF8N7IRGe9UVIqqrINthw==
+  dependencies:
+    bignumber.js "^9.1.0"
+    rxjs "6"
 
 "@lido-sdk/constants@1.8.1", "@lido-sdk/constants@^1.8.1":
   version "1.8.1"
@@ -3186,6 +3274,11 @@
   resolved "https://registry.yarnpkg.com/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz#9bd0b47f26b5a3151be21ba4ce9f5fa457c5f190"
   integrity sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==
 
+"@types/w3c-web-hid@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@types/w3c-web-hid/-/w3c-web-hid-1.0.3.tgz#e08587a7d737f8654ea6bc0a88689ce5d3ce2d19"
+  integrity sha512-eTQRkPd2JukZfS9+kRtrBAaTCCb6waGh5X8BJHmH1MiVQPLMYwm4+EvhwFfOo9SDna15o9dFAwmWwN6r/YM53A==
+
 "@types/ws@^7.4.4":
   version "7.4.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
@@ -3953,6 +4046,15 @@ axios@^0.26.1:
   dependencies:
     follow-redirects "^1.14.8"
 
+axios@^1.3.4:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.4.0.tgz#38a7bf1224cd308de271146038b551d725f0be1f"
+  integrity sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -4123,6 +4225,11 @@ bignumber.js@^9.0.2:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
   integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
+
+bignumber.js@^9.1.0:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
+  integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -4519,6 +4626,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
@@ -4859,6 +4971,13 @@ duplexify@^4.1.2:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
     stream-shift "^1.0.0"
+
+eip55@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eip55/-/eip55-2.1.1.tgz#28b743c4701ac3c811b1e9fe67e39cf1d0781b96"
+  integrity sha512-WcagVAmNu2Ww2cDUfzuWVntYwFxbvZ5MvIyLZpMjTTkjD6sCvkGOiS86jTppzu9/gWsc8isLHAeMBWK02OnZmA==
+  dependencies:
+    keccak "^3.0.3"
 
 electron-to-chromium@^1.4.251:
   version "1.4.284"
@@ -5625,7 +5744,7 @@ flatted@^3.1.0, flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.14.8:
+follow-redirects@^1.14.8, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -6925,6 +7044,15 @@ keccak@^3.0.1:
     node-gyp-build "^4.2.0"
     readable-stream "^3.6.0"
 
+keccak@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.3.tgz#4bc35ad917be1ef54ff246f904c2bbbf9ac61276"
+  integrity sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==
+  dependencies:
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
+    readable-stream "^3.6.0"
+
 keyvaluestorage-interface@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz#13ebdf71f5284ad54be94bd1ad9ed79adad515ff"
@@ -7786,6 +7914,11 @@ proxy-compare@2.5.1:
   resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.5.1.tgz#17818e33d1653fbac8c2ec31406bce8a2966f600"
   integrity sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -7880,7 +8013,7 @@ react-collapsed@3.0.2:
     raf "^3.4.1"
     tiny-warning "^1.0.3"
 
-react-dom@17.0.2:
+react-dom@17.0.2, react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -7935,7 +8068,7 @@ react-transition-group@4:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@17.0.2:
+react@17.0.2, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
### Changes
1. The code is moved to Reef Knot from (closes UI-89):
- https://github.com/lidofinance/ledgerhq-frame-connector
- https://github.com/lidofinance/ledgerhq-connector

The connectors are now stored in single `@reef-knot/ledger-connector` package

2. Pass supportedChainIds to LedgerHQFrameConnector following this:
https://github.com/lidofinance/ledgerhq-frame-connector/pull/11