### PR TITLE
Fix: ledgerService import

### DIFF
--- a/packages/connectors/ledger-connector/CHANGELOG.md
+++ b/packages/connectors/ledger-connector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/ledger-connector
 
+## 1.0.1
+
+### Patch Changes
+
+- Fix ledgerService import
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ledger-connector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connectors/ledger-connector/src/hid/signer.ts
+++ b/packages/connectors/ledger-connector/src/hid/signer.ts
@@ -1,5 +1,4 @@
-import Eth from '@ledgerhq/hw-app-eth';
-import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
+import Eth, { ledgerService } from '@ledgerhq/hw-app-eth';
 import {
   LoadConfig,
   ResolutionConfig,

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.5.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/ledger-connector@1.0.1
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -49,6 +49,6 @@
     "@reef-knot/wallets-list": "1.4.2",
     "@reef-knot/wallets-helpers": "1.1.2",
     "@reef-knot/types": "1.2.1",
-    "@reef-knot/ledger-connector": "1.0.0"
+    "@reef-knot/ledger-connector": "1.0.1"
   }
 }


### PR DESCRIPTION
Fixes the issue: `TypeError: _ledgerhq_hw_app_eth_lib_services_ledger__WEBPACK_IMPORTED_MODULE_2__.resolveTransaction is not a function`
The issue could happen in runtime in a project, which uses the `reef-knot` package.
The reason of the issue: ledgerService wasn't imported properly, named import fixes it.