### PR TITLE
Fix: warn instead of throw when WC project id is empty

### DIFF
--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.6.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/wallets-helpers@1.1.4
+
 ## 1.6.0
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -47,7 +47,7 @@
     "@reef-knot/ui-react": "1.0.6",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/wallets-list": "1.4.3",
-    "@reef-knot/wallets-helpers": "1.1.3",
+    "@reef-knot/wallets-helpers": "1.1.4",
     "@reef-knot/types": "1.2.2",
     "@reef-knot/ledger-connector": "1.0.1"
   }

--- a/packages/wallets-helpers/CHANGELOG.md
+++ b/packages/wallets-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallets-helpers
 
+## 1.1.4
+
+### Patch Changes
+
+- fix: warn instead of throw when WC project id is empty
+
 ## 1.1.3
 
 ### Patch Changes

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-helpers",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets-helpers/src/walletconnect/getWalletConnectConnector.ts
+++ b/packages/wallets-helpers/src/walletconnect/getWalletConnectConnector.ts
@@ -14,7 +14,7 @@ export const getWalletConnectConnector = ({
   chains: Chain[];
 }) => {
   if (!projectId) {
-    throw new Error(
+    console.warn(
       'No WalletConnect Project ID found, it is required by WalletConnect v2: https://docs.walletconnect.com/2.0/cloud/relay#project-id',
     );
   }


### PR DESCRIPTION
Throwing an error in this case can break a build for a project which doesn't provide the ID on the build step.