### PR TITLE
Fix: connection rejection logic during mobile browser autoconnect

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.6.2
+
+### Patch Changes
+
+- fix: connection rejection logic during mobile browser autoconnect
+
 ## 1.6.1
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -46,7 +46,7 @@
     "@reef-knot/ui-react": "^1.0.7",
     "@reef-knot/wallets-icons": "^1.0.0",
     "@reef-knot/wallets-helpers": "^1.1.5",
-    "@reef-knot/web3-react": "^1.4.1",
+    "@reef-knot/web3-react": "^1.4.2",
     "@types/ua-parser-js": "^0.7.36",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/WalletsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext, useState, ReactElement } from 'react';
 import { Button, Modal } from '@reef-knot/ui-react';
 import { AcceptTermsModalContext, LS_KEY_TERMS_ACCEPTANCE } from '@reef-knot/core-react';
 import {
@@ -10,7 +10,7 @@ import { Terms } from '../Terms';
 import { WalletsButtonsContainer, CommonButtonsContainer } from './styles';
 import { NOOP, useLocalStorage } from '../../helpers';
 
-export function WalletsModal(props: WalletsModalProps): JSX.Element {
+export function WalletsModal(props: WalletsModalProps): ReactElement {
   const {
     onClose,
     shouldInvertWalletIcon = false,
@@ -102,7 +102,6 @@ export function WalletsModal(props: WalletsModalProps): JSX.Element {
               disabled={!termsChecked}
               onClick={() => {
                 acceptTermsModal?.onContinue?.();
-                acceptTermsModal?.setVisible(false);
               }}
             >
               Connect

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 1.7.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.6.2
+  - @reef-knot/web3-react@1.4.2
+
 ## 1.7.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,9 +41,9 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.6.1",
+    "@reef-knot/connect-wallet-modal": "1.6.2",
     "@reef-knot/core-react": "1.5.1",
-    "@reef-knot/web3-react": "1.4.1",
+    "@reef-knot/web3-react": "1.4.2",
     "@reef-knot/ui-react": "1.0.7",
     "@reef-knot/wallets-icons": "1.0.0",
     "@reef-knot/wallets-list": "1.4.4",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/web3-react
 
+## 1.4.2
+
+### Patch Changes
+
+- fix: connection rejection logic during mobile browser autoconnect
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/hooks/useAutoConnect.ts
+++ b/packages/web3-react/src/hooks/useAutoConnect.ts
@@ -48,7 +48,13 @@ export const useEagerConnector = (connectors: ConnectorsContextValue) => {
       })();
       if (!connector) return;
 
-      const connectWallet = () => activate(connector, undefined, true);
+      const connectWallet = async () => {
+        await activate(connector, undefined, true);
+        // Hide the modal if a user approved the connection in a wallet's UI.
+        // If a user rejects the connection, then an error is thrown
+        // and the following code is not being reached, the modal stays visible.
+        acceptTermsModal.setVisible?.(false);
+      }
 
       let termsAccepted = false;
       if (typeof window !== 'undefined') {


### PR DESCRIPTION
**Related:** #80 

The issue was found during QA session: if a user rejects the connection via wallet's UI, then the Terms modal window still closes. So the wallet is not connected and it becomes possible to open the common Wallet Connection Modal with a list of all wallets, which is not expected behavior.
This PR fixes the issue.
