### PR TITLE
Set `check: false` for rollup-plugin-typescript2 config

### DIFF
--- a/packages/connect-wallet-modal/rollup.config.js
+++ b/packages/connect-wallet-modal/rollup.config.js
@@ -37,7 +37,8 @@ export default {
     resolve({ extensions, preferBuiltins: true }),
     typescript({
       typescript: ts,
-      tsconfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/connectors/ledger-connector/rollup.config.js
+++ b/packages/connectors/ledger-connector/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/core-react/rollup.config.js
+++ b/packages/core-react/rollup.config.js
@@ -38,6 +38,7 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/reef-knot/rollup.config.js
+++ b/packages/reef-knot/rollup.config.js
@@ -36,6 +36,7 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/ui-react/rollup.config.js
+++ b/packages/ui-react/rollup.config.js
@@ -38,7 +38,8 @@ export default {
     resolve({ extensions, preferBuiltins: true }),
     typescript({
       typescript: ts,
-      tsconfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json',
+      check: false,
     }),
     commonjs(),
     babel({

--- a/packages/wallets-helpers/rollup.config.js
+++ b/packages/wallets-helpers/rollup.config.js
@@ -38,6 +38,7 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets-icons/rollup.config.js
+++ b/packages/wallets-icons/rollup.config.js
@@ -44,6 +44,7 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets-list/rollup.config.js
+++ b/packages/wallets-list/rollup.config.js
@@ -38,6 +38,7 @@ export default {
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/ambire/rollup.config.js
+++ b/packages/wallets/ambire/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/bitkeep/rollup.config.js
+++ b/packages/wallets/bitkeep/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/coin98/rollup.config.js
+++ b/packages/wallets/coin98/rollup.config.js
@@ -45,15 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/exodus/rollup.config.js
+++ b/packages/wallets/exodus/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/okx/rollup.config.js
+++ b/packages/wallets/okx/rollup.config.js
@@ -44,16 +44,8 @@ export default defineConfig({
     }),
     typescript({
       typescript: ts,
+      check: false,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/phantom/rollup.config.js
+++ b/packages/wallets/phantom/rollup.config.js
@@ -45,15 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
-      tsconfigOverride: {
-        compilerOptions: {
-          emitDeclarationOnly: false,
-          noEmit: false,
-          rootDir: 'src',
-        },
-        exclude: ['node_modules', 'dist', '**/*.test.*'],
-        include: ['src/**/*'],
-      },
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/taho/rollup.config.js
+++ b/packages/wallets/taho/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/walletconnect/rollup.config.js
+++ b/packages/wallets/walletconnect/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/zengo/rollup.config.js
+++ b/packages/wallets/zengo/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/wallets/zerion/rollup.config.js
+++ b/packages/wallets/zerion/rollup.config.js
@@ -45,6 +45,7 @@ export default defineConfig({
     typescript({
       typescript: ts,
       tsconfig: 'tsconfig.json',
+      check: false,
     }),
     babel({
       exclude: 'node_modules/**',

--- a/packages/web3-react/rollup.config.js
+++ b/packages/web3-react/rollup.config.js
@@ -36,6 +36,7 @@ export default {
     resolve({ extensions, preferBuiltins: true }),
     typescript({
       typescript: ts,
+      check: false,
       tsconfig: 'tsconfig.json',
       tsconfigOverride: {
         compilerOptions: {


### PR DESCRIPTION
Disable ts diagnostic checks to speed up compilation during development and get rid of annoying issues with types rebuilding during development.

See https://www.npmjs.com/package/rollup-plugin-typescript2#plugin-options

> check: true

> Set to false to avoid doing any diagnostic checks on the code. Setting to false is sometimes referred to as transpileOnly by other TypeScript integrations.