### PR TITLE
Update ledgerhq/hw-app-eth (crypto-js alert)

### DIFF
--- a/packages/connectors/ledger-connector/CHANGELOG.md
+++ b/packages/connectors/ledger-connector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/ledger-connector
 
+## 1.1.1
+
+### Patch Changes
+
+- Update ledgerhq/hw-app-eth. Needed to bump `crypto-js` to 4.2.0 to fix dependabot security alert.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ledger-connector",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -44,7 +44,7 @@
     "@ethersproject/strings": "^5.5.0",
     "@ethersproject/transactions": "^5.5.0",
     "@ethersproject/hash": "^5.5.0",
-    "@ledgerhq/hw-app-eth": "^6.34.3",
+    "@ledgerhq/hw-app-eth": "^6.34.8",
     "@ledgerhq/hw-transport": "^6.28.8",
     "@ledgerhq/hw-transport-webhid": "^6.27.19",
     "@ledgerhq/iframe-provider": "0",

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.10.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/ledger-connector@1.1.1
+
 ## 1.10.0
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -49,7 +49,7 @@
     "@reef-knot/wallets-list": "1.5.0",
     "@reef-knot/wallets-helpers": "1.1.5",
     "@reef-knot/types": "1.3.0",
-    "@reef-knot/ledger-connector": "1.1.0"
+    "@reef-knot/ledger-connector": "1.1.1"
   },
   "devDependencies": {
     "eslint-config-custom": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,7 +1779,7 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
 
-"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
+"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.5.0", "@ethersproject/hash@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
   integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
@@ -2313,10 +2313,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.2.tgz#d550e3c1f046e4c796f32a75324b03606b7e226a"
   integrity sha512-mscwGroSJQrCTjtNGBu+18FQbZYA4+q6Tyx6K7CXHl6AwgZKbWfZYdgP2F+fyZcRUdGRsMX8QtvU61VcGGtO1A==
 
-"@ledgerhq/cryptoassets@^9.12.1":
-  version "9.12.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-9.12.1.tgz#8c61af47f37476b66723ced56c090eba5d8b6d8b"
-  integrity sha512-epyuN8HfKFjnE70yu5PY8rOszI7mz+Zb5NSMeFjY85H6zSmaOMplyz8dnZjRUWgl+IeqYXVOSdCHj59sgPp8lA==
+"@ledgerhq/cryptoassets@^11.0.1":
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-11.0.1.tgz#3cac2efb11db025c525fd2bd28b7aa541fa068e5"
+  integrity sha512-VhSA1ydoTnNjoC5c+S/a+YURJV+UNvuLVkRrKpP87zaQ2a+odPkP3EVDrU+G1Dvt/LipA24ZgcpoxXTbO6fQ9Q==
   dependencies:
     invariant "2"
 
@@ -2330,15 +2330,15 @@
     rxjs "6"
     semver "^7.3.5"
 
-"@ledgerhq/domain-service@^1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/domain-service/-/domain-service-1.1.10.tgz#4f4b21c19984ce0088439590b72fc5f338195a34"
-  integrity sha512-SWIabM8PPTvH1DmIsHqC4Pr7wUNKIyw4zak1dX30BxNjhLFWNRIL7IzDqEznwh59O+PWquclMCzP9WsOy9YjOw==
+"@ledgerhq/domain-service@^1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/domain-service/-/domain-service-1.1.13.tgz#e12be51cf677da455d63052891e5bdaca2755779"
+  integrity sha512-8XQl4glEfNyX4BkNhuwe69mzn1VIasWFoKlgXIXf6gc8Rw1Qzcn0LE+/3DBxZ3pC3IWiBnm7MmXMrIaSLjnPNQ==
   dependencies:
-    "@ledgerhq/cryptoassets" "^9.12.1"
+    "@ledgerhq/cryptoassets" "^11.0.1"
     "@ledgerhq/errors" "^6.14.0"
     "@ledgerhq/logs" "^6.10.1"
-    "@ledgerhq/types-live" "^6.39.0"
+    "@ledgerhq/types-live" "^6.41.1"
     axios "^1.3.4"
     eip55 "^2.1.1"
     react "^17.0.2"
@@ -2349,34 +2349,34 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-6.14.0.tgz#0bf253983773ef12eebce2091f463bc719223b37"
   integrity sha512-ZWJw2Ti6Dq1Ott/+qYqJdDWeZm16qI3VNG5rFlb0TQ3UcAyLIQZbnnzzdcVVwVeZiEp66WIpINd/pBdqsHVyOA==
 
-"@ledgerhq/evm-tools@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/evm-tools/-/evm-tools-1.0.6.tgz#a3793175ba7b4a5b3ddcc7fb6bb5dd8a43e1c964"
-  integrity sha512-EVVGX0V5Sare7M2U6xWMUrflXSFdHODeqB3ZqSxOcyM4ikLeV/pjtrZof5XR6ECmf5WhzZAX2X/duUb/5Lhfyg==
+"@ledgerhq/evm-tools@^1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/evm-tools/-/evm-tools-1.0.9.tgz#fb3f99bf7e9648a7ff4f355e0f26b2d1bd29acd9"
+  integrity sha512-yfNFGRDH+D59tZcR/iGBaW5RxKoPglRAolSUVJT+c+YN5DXRdS8yz+WrlhLrusoR4JHpfA3trBfw5KUrBrHY7g==
   dependencies:
-    "@ledgerhq/cryptoassets" "^9.12.1"
-    "@ledgerhq/live-env" "^0.5.0"
-    "@ledgerhq/live-network" "^1.1.6"
+    "@ledgerhq/cryptoassets" "^11.0.1"
+    "@ledgerhq/live-env" "^0.6.0"
+    "@ledgerhq/live-network" "^1.1.7"
     crypto-js "4.1.1"
     ethers "5.7.2"
 
-"@ledgerhq/hw-app-eth@^6.34.3":
-  version "6.34.5"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-6.34.5.tgz#33da41d69419cc9d8766fd3f6b84b5b16b56105b"
-  integrity sha512-qN76FUmB6FM6LpeEWRgfVopDHScr6JJJfteJWIXP58dy64jqQSxTLrJydUjxkYoBI7DfXlq3tcbISDqtJvXziw==
+"@ledgerhq/hw-app-eth@^6.34.3", "@ledgerhq/hw-app-eth@^6.34.8":
+  version "6.34.8"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-6.34.8.tgz#f2e1229307ded234d2cc02e00a7effb9f4b1e721"
+  integrity sha512-sFYRGO7kgiTlgCRPdHJsF69s75TQz3Idi2YGn7eWhM/yxSJiAE1Kt/OLOW2ej68U/mfxI5pDIK8f8AZuK+8RFg==
   dependencies:
     "@ethersproject/abi" "^5.5.0"
     "@ethersproject/rlp" "^5.5.0"
-    "@ledgerhq/cryptoassets" "^9.12.1"
-    "@ledgerhq/domain-service" "^1.1.10"
+    "@ledgerhq/cryptoassets" "^11.0.1"
+    "@ledgerhq/domain-service" "^1.1.13"
     "@ledgerhq/errors" "^6.14.0"
-    "@ledgerhq/evm-tools" "^1.0.6"
+    "@ledgerhq/evm-tools" "^1.0.9"
     "@ledgerhq/hw-transport" "^6.28.8"
     "@ledgerhq/hw-transport-mocker" "^6.27.19"
     "@ledgerhq/logs" "^6.10.1"
-    "@ledgerhq/types-live" "^6.39.0"
+    "@ledgerhq/types-live" "^6.41.1"
     axios "^1.3.4"
-    bignumber.js "^9.1.1"
+    bignumber.js "^9.1.2"
 
 "@ledgerhq/hw-transport-mocker@^6.27.19":
   version "6.27.19"
@@ -2419,21 +2419,21 @@
   dependencies:
     eventemitter3 "^4.0.0"
 
-"@ledgerhq/live-env@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-env/-/live-env-0.5.0.tgz#653597816f3066dc116b94de6972a17f3bfcef81"
-  integrity sha512-f9nGHNcYV0XMyxZTTBsNrnh8KKQoXx6hbixBADDXUDWf8uPiZlh5O41uCQ3ufRoyptCjeiv0nQ6TFxcCK929eA==
+"@ledgerhq/live-env@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-env/-/live-env-0.6.0.tgz#fc4770fe8041cd7f4ba95d56deb9075ac0d89de1"
+  integrity sha512-wWlatg4OT0p2jCmUERBtI6dduSe4BIZiSUuh1uSjQpbnTTPoMVHNjn4U7A4Ns1+Zz5TkmDwXS8yE523cRjjVrg==
   dependencies:
     rxjs "^6.6.7"
     utility-types "^3.10.0"
 
-"@ledgerhq/live-network@^1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-network/-/live-network-1.1.6.tgz#9fe59e92b17a5c8eaa882f61bc7d7eff225ceb55"
-  integrity sha512-T9x+GUEk9wmGwHfzHj0uY7u78tpDankwyTFhXnoTI2i5TCACLNQQjQsMtlhs6kT1ZUKVcZdZSN5Pn1SQJA4nbw==
+"@ledgerhq/live-network@^1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-network/-/live-network-1.1.7.tgz#4838e9858489212ff68248e11c6bf7fd77554957"
+  integrity sha512-OneMFcGRc5DbHWSNG41kfY/81Lm78IxJScIufGMW6beb0Sp6SmlHqkfjwrPLtp1GeHrJ2SqaXAvWROV/AexhUg==
   dependencies:
     "@ledgerhq/errors" "^6.14.0"
-    "@ledgerhq/live-env" "^0.5.0"
+    "@ledgerhq/live-env" "^0.6.0"
     "@ledgerhq/live-promise" "^0.0.1"
     "@ledgerhq/logs" "^6.10.1"
     "@types/node" "^20.2.5"
@@ -2453,12 +2453,12 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-6.10.1.tgz#5bd16082261d7364eabb511c788f00937dac588d"
   integrity sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w==
 
-"@ledgerhq/types-live@^6.39.0":
-  version "6.39.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/types-live/-/types-live-6.39.0.tgz#48997f2d3e4a0e731d36c5e7c4876c643b646214"
-  integrity sha512-PEf/o8SmXiC9zcBiV3K533rLRPZ7+soqe2G5rT57hy9QB3DC1+la2A9tcD6sWiIaNWwdLoztfexE72IdX55oeA==
+"@ledgerhq/types-live@^6.41.1":
+  version "6.41.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/types-live/-/types-live-6.41.1.tgz#734e2e853400715a9fad705ba22413b846f7fcd3"
+  integrity sha512-M9NcGlpyW7383HZ+Wcl+vVj07fKlBLQT29wrrPTW9raj2iq0fzyAaxSQPs0VKX6LghLQSmXG2EdcvQ9v5FakgA==
   dependencies:
-    bignumber.js "^9.1.1"
+    bignumber.js "^9.1.2"
     rxjs "6"
 
 "@lido-sdk/constants@3.2.0", "@lido-sdk/constants@^3.2.0":
@@ -4680,7 +4680,7 @@ bigint-buffer@^1.1.5:
   dependencies:
     bindings "^1.3.0"
 
-bignumber.js@^9.1.1:
+bignumber.js@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==


### PR DESCRIPTION
Needed to bump `crypto-js` to 4.2.0 to fix dependabot security alert:  
https://github.com/lidofinance/reef-knot/security/dependabot/36