### PR TITLE
Fix: ledger connection await timeout

### DIFF
--- a/apps/demo-react/components/ProviderWeb3WithProps.tsx
+++ b/apps/demo-react/components/ProviderWeb3WithProps.tsx
@@ -8,9 +8,9 @@ import { getRPCPath } from '../util/contractTestingUtils';
 import { rpcUrlsString } from '../util/rpc';
 import { WC_PROJECT_ID } from '../util/walletconnectProjectId';
 
-const supportedChains = [goerli, mainnet, holesky];
+const supportedChains = [holesky, mainnet, goerli];
 const supportedChainsIds = supportedChains.map((chain) => chain.id);
-const defaultChainId = goerli.id;
+const defaultChainId = holesky.id;
 
 const jsonRcpBatchProvider = (chain: Chain) => ({
   provider: () =>

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.8.3
+
+### Patch Changes
+
+- Remove 'themeOverride' deprecated prop from Select
+
 ## 1.8.2
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -50,7 +50,7 @@
     "@reef-knot/ui-react": "^1.0.7",
     "@reef-knot/wallets-helpers": "^1.1.5",
     "@reef-knot/wallets-icons": "^1.1.0",
-    "@reef-knot/web3-react": "^1.6.0",
+    "@reef-knot/web3-react": "^1.6.1",
     "@reef-knot/ledger-connector": "^1.1.0",
     "@types/ua-parser-js": "^0.7.36",
     "eslint-config-custom": "*",

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerDerivationPathSelect.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerDerivationPathSelect.tsx
@@ -17,7 +17,7 @@ export const LedgerDerivationPathSelect: FC<{
 }> = ({ onChange, value }) => (
   <Box>
     <TextStyled color="secondary">Select HD derivation path</TextStyled>
-    <Select onChange={onChange} value={value} fullwidth themeOverride="light">
+    <Select onChange={onChange} value={value} fullwidth>
       {DERIVATION_PATHS.map((path) => (
         <Option value={path.template} key={path.template}>
           {path.title}

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 1.10.4
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.8.3
+  - @reef-knot/web3-react@1.6.1
+
 ## 1.10.3
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,9 +41,9 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.8.2",
+    "@reef-knot/connect-wallet-modal": "1.8.3",
     "@reef-knot/core-react": "1.6.0",
-    "@reef-knot/web3-react": "1.6.0",
+    "@reef-knot/web3-react": "1.6.1",
     "@reef-knot/ui-react": "1.0.7",
     "@reef-knot/wallets-icons": "1.1.0",
     "@reef-knot/wallets-list": "1.5.0",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/web3-react
 
+## 1.6.1
+
+### Patch Changes
+
+- Add workaround: await timeout before ledger connector "activate"
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/hooks/useConnectorLedger.ts
+++ b/packages/web3-react/src/hooks/useConnectorLedger.ts
@@ -20,6 +20,15 @@ export const useConnectorLedger = (
 
   const connect = useCallback(async () => {
     disconnect();
+
+    // Workaround for an issue when connection does not happen because of
+    // Warning: Suppressed stale connector activation [object Object]
+    // Reproducible on a stake widget, but not in the reef-knot demo app.
+    // This is web3-react related issue, see https://github.com/Uniswap/web3-react/issues/78
+    // In our case may happen because `disconnect()` on the upper line is not awaited.
+    // Leaving it like this, because web3-react will be removed soon and the code will be rewritten.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
     await activate(ledger, () => {}, true);
     onConnect?.();
   }, [activate, disconnect, ledger, onConnect]);


### PR DESCRIPTION
The main reason of the PR is to add a workaround for an issue when connection does not happen because of `Warning: Suppressed stale connector activation [object Object]`

Also this PR:
- (demo-react) makes demo-react app work with holesky by default
- (connect-wallet-modal) removes deprecated prop from Select
