### PR TITLE
Fix: wrong connector after page reload

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 1.11.1
+
+### Patch Changes
+
+- Add custom connectors for injected wallets, which fixes an issue with autoconnection after page reload.
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connect-wallet-modal/src/components/WalletsModalForEth/WalletsModalForEth.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModalForEth/WalletsModalForEth.tsx
@@ -17,6 +17,7 @@ import { WalletsModalForEthProps } from './types';
 import { WALLET_IDS, WalletId } from '../../constants';
 
 const walletsButtons: { [K in WalletId | string]: React.ComponentType } = {
+  default: ConnectInjected,
   injected: ConnectInjected,
   walletConnect: ConnectWC,
   [WALLET_IDS.METAMASK]: ConnectMetamask,
@@ -32,7 +33,8 @@ function getWalletButton(
   reactKey: string,
   props: ButtonsCommonProps,
 ) {
-  return React.createElement(walletsButtons[walletId], {
+  const component = walletsButtons[walletId] ?? walletsButtons.default;
+  return React.createElement(component, {
     key: reactKey,
     ...props,
   });

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 1.11.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@1.11.1
+  - @reef-knot/wallets-list@1.7.1
+
 ## 1.11.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,12 +41,12 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "1.11.0",
+    "@reef-knot/connect-wallet-modal": "1.11.1",
     "@reef-knot/core-react": "1.7.0",
     "@reef-knot/web3-react": "1.9.1",
     "@reef-knot/ui-react": "1.0.7",
     "@reef-knot/wallets-icons": "1.3.0",
-    "@reef-knot/wallets-list": "1.7.0",
+    "@reef-knot/wallets-list": "1.7.1",
     "@reef-knot/wallets-helpers": "1.1.5",
     "@reef-knot/types": "1.3.0",
     "@reef-knot/ledger-connector": "1.1.1"

--- a/packages/wallets-list/CHANGELOG.md
+++ b/packages/wallets-list/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @reef-knot/wallets-list
 
+## 1.7.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/wallet-adapter-bitkeep@1.1.1
+  - @reef-knot/wallet-adapter-coin98@1.0.1
+  - @reef-knot/wallet-adapter-exodus@1.2.4
+  - @reef-knot/wallet-adapter-brave@1.0.1
+  - @reef-knot/wallet-adapter-okx@1.3.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-list",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,18 +37,18 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/wallet-adapter-exodus": "1.2.3",
+    "@reef-knot/wallet-adapter-exodus": "1.2.4",
     "@reef-knot/wallet-adapter-taho": "1.2.3",
-    "@reef-knot/wallet-adapter-okx": "1.3.0",
+    "@reef-knot/wallet-adapter-okx": "1.3.1",
     "@reef-knot/wallet-adapter-phantom": "1.3.0",
     "@reef-knot/wallet-adapter-walletconnect": "1.2.4",
     "@reef-knot/wallet-adapter-blockchaincom": "1.2.4",
     "@reef-knot/wallet-adapter-zerion": "1.2.4",
     "@reef-knot/wallet-adapter-zengo": "1.2.4",
     "@reef-knot/wallet-adapter-ambire": "1.2.4",
-    "@reef-knot/wallet-adapter-bitkeep": "1.1.0",
-    "@reef-knot/wallet-adapter-coin98": "1.0.0",
-    "@reef-knot/wallet-adapter-brave": "1.0.0"
+    "@reef-knot/wallet-adapter-bitkeep": "1.1.1",
+    "@reef-knot/wallet-adapter-coin98": "1.0.1",
+    "@reef-knot/wallet-adapter-brave": "1.0.1"
   },
   "devDependencies": {
     "@reef-knot/types": "^1.3.0",

--- a/packages/wallets/bitkeep/CHANGELOG.md
+++ b/packages/wallets/bitkeep/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-bitkeep
 
+## 1.1.1
+
+### Patch Changes
+
+- Add custom connectors for injected wallets, which fixes an issue with autoconnection after page reload.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/wallets/bitkeep/package.json
+++ b/packages/wallets/bitkeep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-bitkeep",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets/bitkeep/src/index.ts
+++ b/packages/wallets/bitkeep/src/index.ts
@@ -1,5 +1,5 @@
 import { WalletAdapterType } from '@reef-knot/types';
-import { Ethereum as EthereumTypeWagmi } from '@wagmi/core';
+import { Ethereum as EthereumTypeWagmi, Chain } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import WalletIcon from './icons/bitget.svg';
 
@@ -8,6 +8,19 @@ declare global {
     bitkeep?: {
       ethereum?: EthereumTypeWagmi;
     };
+  }
+}
+
+export class BitgetConnector extends InjectedConnector {
+  readonly id = 'bitget';
+  readonly name = 'Bitget';
+  constructor(chains: Chain[]) {
+    super({
+      chains,
+      options: {
+        getProvider: () => globalThis.window?.bitkeep?.ethereum,
+      },
+    });
   }
 }
 
@@ -21,13 +34,7 @@ export const Bitget: WalletAdapterType = ({ chains }) => ({
   downloadURLs: {
     default: 'https://web3.bitget.com/',
   },
-  connector: new InjectedConnector({
-    chains,
-    options: {
-      name: 'Bitget',
-      getProvider: () => globalThis.window?.bitkeep?.ethereum,
-    },
-  }),
+  connector: new BitgetConnector(chains),
 });
 
 // BitKeep is the previous name of the wallet.

--- a/packages/wallets/brave/CHANGELOG.md
+++ b/packages/wallets/brave/CHANGELOG.md
@@ -1,13 +1,7 @@
-# @reef-knot/wallet-adapter-coin98
+# @reef-knot/wallet-adapter-brave
 
 ## 1.0.1
 
 ### Patch Changes
 
 - Add custom connectors for injected wallets, which fixes an issue with autoconnection after page reload.
-
-## 1.0.0
-
-### Minor Changes
-
-- e2074ed: Make Coin98 wallet to use Wallet Adapter API

--- a/packages/wallets/brave/package.json
+++ b/packages/wallets/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-brave",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets/brave/src/index.ts
+++ b/packages/wallets/brave/src/index.ts
@@ -1,11 +1,25 @@
 import { WalletAdapterType } from '@reef-knot/types';
-import { Ethereum as EthereumTypeWagmi } from '@wagmi/core';
+import { Ethereum as EthereumTypeWagmi, Chain } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { WalletIcon } from './icons/index.js';
 
 declare global {
   interface Window {
     braveEthereum?: EthereumTypeWagmi;
+  }
+}
+
+export class BraveConnector extends InjectedConnector {
+  readonly id = 'brave';
+  readonly name = 'Brave';
+  constructor(chains: Chain[]) {
+    super({
+      chains,
+      options: {
+        getProvider: () =>
+          globalThis.window?.braveEthereum || globalThis.window?.ethereum,
+      },
+    });
   }
 }
 
@@ -19,12 +33,5 @@ export const Brave: WalletAdapterType = ({ chains }) => ({
   downloadURLs: {
     default: 'https://brave.com/wallet/',
   },
-  connector: new InjectedConnector({
-    chains,
-    options: {
-      name: 'Brave',
-      getProvider: () =>
-        globalThis.window?.braveEthereum || globalThis.window?.ethereum,
-    },
-  }),
+  connector: new BraveConnector(chains),
 });

--- a/packages/wallets/coin98/package.json
+++ b/packages/wallets/coin98/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coin98",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets/coin98/src/index.ts
+++ b/packages/wallets/coin98/src/index.ts
@@ -1,5 +1,5 @@
 import { WalletAdapterType } from '@reef-knot/types';
-import { Ethereum as EthereumTypeWagmi } from '@wagmi/core';
+import { Ethereum as EthereumTypeWagmi, Chain } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import WalletIcon from './icons/coin98.svg';
 
@@ -17,6 +17,20 @@ declare global {
   }
 }
 
+export class Coin98Connector extends InjectedConnector {
+  readonly id = 'coin98';
+  readonly name = 'Coin98';
+  constructor(chains: Chain[]) {
+    super({
+      chains,
+      options: {
+        getProvider: () =>
+          globalThis.window?.coin98?.provider || globalThis.window?.ethereum,
+      },
+    });
+  }
+}
+
 export const Coin98: WalletAdapterType = ({ chains }) => ({
   walletName: 'Coin98',
   walletId: 'coin98',
@@ -29,12 +43,5 @@ export const Coin98: WalletAdapterType = ({ chains }) => ({
     ios: 'https://ios.coin98.com',
     android: 'https://android.coin98.com',
   },
-  connector: new InjectedConnector({
-    chains,
-    options: {
-      name: 'Coin98',
-      getProvider: () =>
-        globalThis.window?.coin98?.provider || globalThis.window?.ethereum,
-    },
-  }),
+  connector: new Coin98Connector(chains),
 });

--- a/packages/wallets/exodus/CHANGELOG.md
+++ b/packages/wallets/exodus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-exodus
 
+## 1.2.4
+
+### Patch Changes
+
+- Add custom connectors for injected wallets, which fixes an issue with autoconnection after page reload.
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-exodus",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets/exodus/src/index.ts
+++ b/packages/wallets/exodus/src/index.ts
@@ -1,7 +1,7 @@
 import { WalletAdapterType } from '@reef-knot/types';
-import { Ethereum as EthereumTypeWagmi } from '@wagmi/core';
-import { InjectedConnector } from 'wagmi/connectors/injected';
 import WalletIcon from './icons/exodus.svg';
+import { Ethereum as EthereumTypeWagmi, Chain } from '@wagmi/core';
+import { InjectedConnector } from '@wagmi/connectors/injected';
 
 declare global {
   interface Ethereum extends EthereumTypeWagmi {
@@ -9,6 +9,20 @@ declare global {
   }
   interface Window {
     exodus?: { ethereum?: Ethereum };
+  }
+}
+
+export class ExodusConnector extends InjectedConnector {
+  readonly id = 'exodus';
+  readonly name = 'Exodus';
+  constructor(chains: Chain[]) {
+    super({
+      chains,
+      options: {
+        getProvider: () =>
+          globalThis.window?.exodus?.ethereum || globalThis.window?.ethereum,
+      },
+    });
   }
 }
 
@@ -21,12 +35,5 @@ export const Exodus: WalletAdapterType = ({ chains }) => ({
   downloadURLs: {
     default: 'https://www.exodus.com/download/',
   },
-  connector: new InjectedConnector({
-    chains,
-    options: {
-      name: 'Exodus',
-      getProvider: () =>
-        globalThis.window?.exodus?.ethereum || globalThis.window?.ethereum,
-    },
-  }),
+  connector: new ExodusConnector(chains),
 });

--- a/packages/wallets/okx/CHANGELOG.md
+++ b/packages/wallets/okx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-okx
 
+## 1.3.1
+
+### Patch Changes
+
+- Add custom connectors for injected wallets, which fixes an issue with autoconnection after page reload.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-okx",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets/okx/src/index.ts
+++ b/packages/wallets/okx/src/index.ts
@@ -1,5 +1,5 @@
 import { WalletAdapterType } from '@reef-knot/types';
-import { Ethereum as EthereumTypeWagmi } from '@wagmi/core';
+import { Ethereum as EthereumTypeWagmi, Chain } from '@wagmi/core';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import WalletIcon from './icons/okx.svg';
 import WalletIconInverted from './icons/okx-inverted.svg';
@@ -16,6 +16,20 @@ declare global {
   }
 }
 
+export class OkxConnector extends InjectedConnector {
+  readonly id = 'okx';
+  readonly name = 'OKX Wallet';
+  constructor(chains: Chain[]) {
+    super({
+      chains,
+      options: {
+        getProvider: () =>
+          globalThis.window?.okxwallet || globalThis.window?.ethereum,
+      },
+    });
+  }
+}
+
 export const Okx: WalletAdapterType = ({ chains }) => ({
   walletName: 'OKX Wallet',
   walletId: 'okx',
@@ -29,12 +43,5 @@ export const Okx: WalletAdapterType = ({ chains }) => ({
   downloadURLs: {
     default: 'https://www.okx.com/download',
   },
-  connector: new InjectedConnector({
-    chains,
-    options: {
-      name: 'OKX Wallet',
-      getProvider: () =>
-        globalThis.window?.okxwallet || globalThis.window?.ethereum,
-    },
-  }),
+  connector: new OkxConnector(chains),
 });


### PR DESCRIPTION
Resolves SI-954

We have several Wallet Adapters. Each Wallet Adapter uses its own instance of InjectedConnector.
1. Autoconnect by wagmi checks last used connector first: [here](https://github.com/wagmi-dev/wagmi/blob/fcdbe3531e6d05cda4a4a511bae1ad4c9e426d88/packages/core/src/client.ts#L229)
2. Last used connector is stored in localstorage [like this](https://github.com/wagmi-dev/wagmi/blob/fcdbe3531e6d05cda4a4a511bae1ad4c9e426d88/packages/core/src/client.ts#L296) and is being set [here](https://github.com/wagmi-dev/wagmi/blob/88afc84978afe9689ab7364633e4422ecd7699ea/packages/core/src/actions/accounts/connect.ts#L39) using connector's id
3. The problem is that all InjectedConnectors have the `id === 'injected'` property: [see here](https://github.com/wagmi-dev/references/blob/6c841d4d6d264f74d5c75cd6fc12571cf5041187/packages/connectors/src/injected.ts#L48)
4. During autoconnect, there is a sorting of connectors wallet, which makes a last used connector (with `injected` id in this case) to be the first: [here](https://github.com/wagmi-dev/wagmi/blob/fcdbe3531e6d05cda4a4a511bae1ad4c9e426d88/packages/core/src/client.ts#L231). Since we have several connectors with `injected` id, we get the wrong connector here.

This PR wraps injected connectors for injected wallets in custom connectors with different connector IDs.