### PR TITLE
Fix: Terms modal not closing during autoconnect

### DIFF
--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.11.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/web3-react@1.9.1
+
 ## 1.10.7
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -43,7 +43,7 @@
   "dependencies": {
     "@reef-knot/connect-wallet-modal": "1.11.0",
     "@reef-knot/core-react": "1.7.0",
-    "@reef-knot/web3-react": "1.9.0",
+    "@reef-knot/web3-react": "1.9.1",
     "@reef-knot/ui-react": "1.0.7",
     "@reef-knot/wallets-icons": "1.3.0",
     "@reef-knot/wallets-list": "1.7.0",

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/web3-react
 
+## 1.9.1
+
+### Patch Changes
+
+- Fix an issue with the terms modal not closing until page restart.
+
 ## 1.9.0
 
 ### Minor Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/web3-react/src/hooks/useAutoConnect.ts
+++ b/packages/web3-react/src/hooks/useAutoConnect.ts
@@ -10,6 +10,13 @@ import { useDisconnect } from './useDisconnect';
 import { ConnectorsContextValue } from '../context';
 import { isDappBrowserProvider } from '../helpers';
 
+const isTermsAccepted = () => {
+  if (typeof window !== 'undefined') {
+    return window.localStorage?.getItem(LS_KEY_TERMS_ACCEPTANCE) === 'true';
+  }
+  return false;
+};
+
 export const useAutoConnect = (connectors: ConnectorsContextValue) => {
   useEagerConnector(connectors);
   useSaveConnectorToLS();
@@ -59,7 +66,7 @@ export const useEagerConnector = (connectors: ConnectorsContextValue) => {
           error = e as Error;
         }
         if (shouldAutoConnectApp) {
-          if (!termsAccepted || error) {
+          if (!isTermsAccepted() || error) {
             acceptTermsModal.setError?.(error);
             acceptTermsModal.setVisible?.(true);
           } else {
@@ -69,13 +76,7 @@ export const useEagerConnector = (connectors: ConnectorsContextValue) => {
         }
       };
 
-      let termsAccepted = false;
-      if (typeof window !== 'undefined') {
-        termsAccepted =
-          window.localStorage?.getItem(LS_KEY_TERMS_ACCEPTANCE) === 'true';
-      }
-
-      if (shouldAutoConnectApp && !termsAccepted) {
+      if (shouldAutoConnectApp && !isTermsAccepted()) {
         acceptTermsModal.setOnContinue?.(() => connectWallet);
         acceptTermsModal.setVisible?.(true);
         return;


### PR DESCRIPTION
Fixes an issue with the Terms modal not closing after successful connect until page restart.