### PR TITLE
Fix name of the "wallet-adapter-browser-extension" package

### DIFF
--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 1.15.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/wallets-list@1.11.1
+
 ## 1.14.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -45,7 +45,7 @@
     "@reef-knot/core-react": "1.8.1",
     "@reef-knot/web3-react": "1.13.0",
     "@reef-knot/ui-react": "1.0.8",
-    "@reef-knot/wallets-list": "1.11.0",
+    "@reef-knot/wallets-list": "1.11.1",
     "@reef-knot/wallets-helpers": "1.1.5",
     "@reef-knot/types": "1.4.0",
     "@reef-knot/ledger-connector": "2.0.0"

--- a/packages/wallets-list/CHANGELOG.md
+++ b/packages/wallets-list/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallets-list
 
+## 1.11.1
+
+### Patch Changes
+
+- Fix name of the 'wallet-adapter-browser-extension' package
+
 ## 1.11.0
 
 ### Minor Changes

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-list",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,7 +37,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/wallet-adapter-browserExtension": "1.0.0",
+    "@reef-knot/wallet-adapter-browser-extension": "1.0.0",
     "@reef-knot/wallet-adapter-metamask": "1.0.0",
     "@reef-knot/wallet-adapter-okx": "1.3.1",
     "@reef-knot/wallet-adapter-exodus": "1.2.4",

--- a/packages/wallets-list/src/ethereum.ts
+++ b/packages/wallets-list/src/ethereum.ts
@@ -1,5 +1,5 @@
 import { WalletsListType } from '@reef-knot/types';
-import { BrowserExtension } from '@reef-knot/wallet-adapter-browserExtension';
+import { BrowserExtension } from '@reef-knot/wallet-adapter-browser-extension';
 import { MetaMask } from '@reef-knot/wallet-adapter-metamask';
 import { Okx } from '@reef-knot/wallet-adapter-okx';
 import { Exodus } from '@reef-knot/wallet-adapter-exodus';

--- a/packages/wallets/browserExtension/package.json
+++ b/packages/wallets/browserExtension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reef-knot/wallet-adapter-browserExtension",
+  "name": "@reef-knot/wallet-adapter-browser-extension",
   "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/turbo/generators/wallet/templates/package.json.hbs
+++ b/turbo/generators/wallet/templates/package.json.hbs
@@ -1,5 +1,5 @@
 {
-  "name": "@reef-knot/wallet-adapter-{{walletId}}",
+  "name": "@reef-knot/wallet-adapter-{{kebabCase walletId}}",
   "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes this issue during publishing to NPM:

> error an error occurred while publishing @reef-knot/wallet-adapter-browserExtension: E400 400 Bad Request - PUT https://registry.npmjs.org/@reef-knot%2fwallet-adapter-browserExtension - "@reef-knot/wallet-adapter-browserExtension" is invalid for new packages 
