### PR TITLE
Fix: isAutoConnectionSuitable

### DIFF
--- a/apps/demo-react/components/ConnectDisconnect.tsx
+++ b/apps/demo-react/components/ConnectDisconnect.tsx
@@ -1,6 +1,6 @@
 import { useWeb3 } from 'reef-knot/web3-react';
 import {
-  useConnectorInfo,
+  useAutoConnectCheck,
   useEagerConnect,
   useForceDisconnect,
 } from 'reef-knot/core-react';
@@ -11,7 +11,7 @@ const ConnectDisconnect = (props: { handleOpen: () => void }) => {
   const { handleOpen } = props;
   const { forceDisconnect } = useForceDisconnect();
   const { account } = useWeb3();
-  const { isAutoConnectionSuitable } = useConnectorInfo();
+  const { isAutoConnectionSuitable } = useAutoConnectCheck();
   const { eagerConnect } = useEagerConnect();
 
   const handleDisconnect = () => {

--- a/packages/core-react/CHANGELOG.md
+++ b/packages/core-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/core-react
 
+## 2.1.1
+
+### Patch Changes
+
+- Fix isAutoConnectionSuitable, add a separate useAutoConnectCheck hook
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/core-react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/core-react/src/hooks/index.ts
+++ b/packages/core-react/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './useReefKnotContext';
 export * from './useAutoConnect';
+export * from './useAutoConnectCheck';
 export * from './useEagerConnect';
 export * from './useDisconnect';
 export * from './useConnectorInfo';

--- a/packages/core-react/src/hooks/useAutoConnectCheck.ts
+++ b/packages/core-react/src/hooks/useAutoConnectCheck.ts
@@ -1,0 +1,15 @@
+import { useReefKnotContext } from './useReefKnotContext';
+
+export const useAutoConnectCheck = () => {
+  const { walletDataList } = useReefKnotContext();
+  const autoConnectOnlyAdapters = walletDataList.filter(
+    ({ autoConnectOnly }) => autoConnectOnly,
+  );
+  const isAutoConnectionSuitable = autoConnectOnlyAdapters.some((adapter) =>
+    adapter.detector?.(),
+  );
+
+  return {
+    isAutoConnectionSuitable,
+  };
+};

--- a/packages/core-react/src/hooks/useConnectorInfo.ts
+++ b/packages/core-react/src/hooks/useConnectorInfo.ts
@@ -12,17 +12,16 @@ type ConnectorInfo = {
   isLedger: boolean;
   isLedgerLive: boolean;
   isDappBrowser: boolean;
-  isAutoConnectionSuitable: boolean;
 };
 
 export const useConnectorInfo = (): ConnectorInfo => {
   const { connector } = useAccount();
 
+  // These checks are working only for connected wallets! There is no connector if a wallet is not connected yet.
   const isLedger = connector instanceof LedgerHIDConnector;
   const isLedgerLive = connector instanceof LedgerLiveConnector;
   const isGnosis = connector instanceof SafeConnector;
   const isDappBrowser = !!globalThis.window?.ethereum && isMobileOrTablet;
-  const isAutoConnectionSuitable = isLedgerLive || isGnosis || isDappBrowser;
 
   let connectorName = connector?.name;
 
@@ -37,6 +36,5 @@ export const useConnectorInfo = (): ConnectorInfo => {
     isLedger,
     isLedgerLive,
     isDappBrowser,
-    isAutoConnectionSuitable,
   };
 };

--- a/packages/core-react/src/hooks/useDisconnect.ts
+++ b/packages/core-react/src/hooks/useDisconnect.ts
@@ -1,7 +1,7 @@
 import { useCallback, useContext } from 'react';
 import { useAccount, useDisconnect as useDisconnectWagmi } from 'wagmi';
-import { useConnectorInfo } from './useConnectorInfo';
 import { AcceptTermsModalContext } from '../context/acceptTermsModal';
+import { useAutoConnectCheck } from './useAutoConnectCheck';
 
 export const useForceDisconnect = () => {
   const { disconnect } = useDisconnectWagmi();
@@ -23,7 +23,7 @@ export const useDisconnect = (): {
   const { isConnected } = useAccount();
   const { disconnect } = useDisconnectWagmi();
 
-  const { isAutoConnectionSuitable } = useConnectorInfo();
+  const { isAutoConnectionSuitable } = useAutoConnectCheck();
   const available = isConnected && !isAutoConnectionSuitable;
 
   return {

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 2.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/core-react@2.1.1
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@reef-knot/connect-wallet-modal": "2.1.0",
-    "@reef-knot/core-react": "2.1.0",
+    "@reef-knot/core-react": "2.1.1",
     "@reef-knot/web3-react": "2.1.0",
     "@reef-knot/ui-react": "1.0.8",
     "@reef-knot/wallets-list": "1.12.0",


### PR DESCRIPTION
Current `isAutoConnectionSuitable` is working only for connected wallets by mistake.
This PR fixes it and moves this check to a separate `useAutoConnectCheck` hook.