### PR TITLE
fix: wallets modal metrics props pass fixed

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/connect-wallet-modal
 
+## 5.2.2
+
+### Patch Changes
+
+- Wallets modal: metrics props pass fixed
+
 ## 5.2.1
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connect-wallet-modal/src/components/WalletsModal/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/packages/connect-wallet-modal/src/components/WalletsModal/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -21,6 +21,8 @@ type ConnectWalletModalProps = WalletsModalProps & {
 
 export const ConnectWalletModal = ({
   onCloseSuccess,
+  onClickWalletsMore,
+  onClickWalletsLess,
   ...passedDownProps
 }: ConnectWalletModalProps) => {
   const {
@@ -29,8 +31,6 @@ export const ConnectWalletModal = ({
     buttonComponentsByConnectorId,
     walletsShown,
     walletsPinned,
-    onClickWalletsMore,
-    onClickWalletsLess,
     walletsDisplayInitialCount = 6,
   } = passedDownProps;
 

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,12 @@
 # reef-knot
 
+## 5.2.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@5.2.2
+
 ## 5.2.2
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,7 +41,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "5.2.1",
+    "@reef-knot/connect-wallet-modal": "5.2.2",
     "@reef-knot/core-react": "4.1.1",
     "@reef-knot/web3-react": "4.0.1",
     "@reef-knot/ui-react": "2.1.2",


### PR DESCRIPTION
Fixed:

<img width="777" alt="image" src="https://github.com/user-attachments/assets/288b623b-2d5f-4165-b272-cfcb43c2b73d">

<img width="820" alt="image" src="https://github.com/user-attachments/assets/2154ec43-7e31-4f83-af5d-1be3e9fff8c1">

