### PR TITLE
Add peer deps to root package

### DIFF
--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # reef-knot
 
+## 5.3.0
+
+### Minor Changes
+
+- Add peer dependencies from subpackages to reef-knot root package
+
 ## 5.2.3
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -55,7 +55,6 @@
     "@tanstack/react-query": "^5.51.1",
     "react": ">=18",
     "react-dom": ">=18",
-    "react-is": ">=18",
     "styled-components": "^5.3.5",
     "viem": "2.13.3",
     "wagmi": "2.11.2"

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -50,6 +50,18 @@
     "@reef-knot/types": "2.0.1",
     "@reef-knot/ledger-connector": "4.1.0"
   },
+  "peerDependencies": {
+    "@lidofinance/lido-ui": "^3.18.0",
+    "@tanstack/react-query": "^5.51.1",
+    "@types/ua-parser-js": "0.7.39",
+    "react": ">=18",
+    "react-dom": ">=18",
+    "react-is": ">=18",
+    "styled-components": "^5.3.5",
+    "ua-parser-js": "1.0.37",
+    "viem": "2.13.3",
+    "wagmi": "2.11.2"
+  },
   "devDependencies": {
     "eslint-config-custom": "*"
   }

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -53,12 +53,10 @@
   "peerDependencies": {
     "@lidofinance/lido-ui": "^3.18.0",
     "@tanstack/react-query": "^5.51.1",
-    "@types/ua-parser-js": "0.7.39",
     "react": ">=18",
     "react-dom": ">=18",
     "react-is": ">=18",
     "styled-components": "^5.3.5",
-    "ua-parser-js": "1.0.37",
     "viem": "2.13.3",
     "wagmi": "2.11.2"
   },

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -47,7 +47,6 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "react-is": ">=18",
     "styled-components": "5",
     "wagmi": "2.11.2"
   },
@@ -56,7 +55,6 @@
     "eslint-config-custom": "*",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-is": "18.2.0",
     "styled-components": "^5.3.6",
     "wagmi": "2.11.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -36,17 +36,17 @@
     "dev": "dev=on rollup -c -w",
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
-  "devDependencies": {
+  "dependencies": {
     "@types/ua-parser-js": "0.7.39",
-    "eslint-config-custom": "*",
-    "wagmi": "2.11.2",
     "ua-parser-js": "1.0.37"
   },
+  "devDependencies": {
+    "eslint-config-custom": "*",
+    "wagmi": "2.11.2"
+  },
   "peerDependencies": {
-    "@types/ua-parser-js": "0.7.39",
     "react": ">=18",
     "wagmi": "2.11.2",
-    "ua-parser-js": "1.0.37",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9341,11 +9341,6 @@ react-error-boundary@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-react-is@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
-  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
This is an attempt to fix the issue when yarn v3 doesn't correctly install peer deps from the sub-packages of reef-knot (see https://github.com/lidofinance/lido-ethereum-sdk/pull/145)