### PR TITLE
refactor: reef knot provider naming improved and config prop defined

### DIFF
--- a/apps/demo-react/components/ConfigContextProviders.tsx
+++ b/apps/demo-react/components/ConfigContextProviders.tsx
@@ -3,7 +3,7 @@ import { http, WagmiProvider, createConfig } from 'wagmi';
 import { goerli, mainnet, holesky } from 'wagmi/chains';
 import {
   AutoConnect,
-  ReefKnot,
+  ReefKnotProvider,
   getWalletsDataList,
 } from 'reef-knot/core-react';
 import { WalletsListEthereum } from 'reef-knot/wallets';
@@ -34,6 +34,12 @@ const config = createConfig({
 
 const queryClient = new QueryClient();
 
+const reefKnotConfig = {
+  rpc: rpcUrlsString,
+  chains: SUPPORTED_CHAINS,
+  walletDataList: walletsDataList,
+};
+
 const ConfigContextProviders = ({
   children,
 }: {
@@ -42,16 +48,12 @@ const ConfigContextProviders = ({
   return (
     <WagmiProvider config={config} reconnectOnMount={false}>
       <QueryClientProvider client={queryClient}>
-        <ReefKnot
-          rpc={rpcUrlsString}
-          chains={SUPPORTED_CHAINS}
-          walletDataList={walletsDataList}
-        >
+        <ReefKnotProvider config={reefKnotConfig}>
           <AutoConnect autoConnect />
           <ProviderSDKWithProps defaultChainId={DEFAULT_CHAIN.id}>
             {children}
           </ProviderSDKWithProps>
-        </ReefKnot>
+        </ReefKnotProvider>
       </QueryClientProvider>
     </WagmiProvider>
   );

--- a/packages/core-react/src/context/reefKnot.tsx
+++ b/packages/core-react/src/context/reefKnot.tsx
@@ -3,38 +3,27 @@ import { ReefKnotModalContextProvider } from './reefKnotModalContext';
 import type { Chain } from 'wagmi/chains';
 import type { WalletAdapterData } from '@reef-knot/types';
 
-export interface ReefKnotContextProps {
-  walletDataList: WalletAdapterData[];
-  rpc: Record<number, string>;
-  chains: readonly [Chain, ...Chain[]];
-  children?: ReactNode;
-}
-
-export type ReefKnotContextValue = {
+export type ReefKnotProviderConfig = {
   rpc: Record<number, string>;
   walletDataList: WalletAdapterData[];
   chains: readonly [Chain, ...Chain[]];
 };
 
+export interface ReefKnotContextProps {
+  config: ReefKnotProviderConfig;
+  children?: ReactNode;
+}
+
+export type ReefKnotContextValue = ReefKnotProviderConfig;
+
 export const ReefKnotContext = createContext({} as ReefKnotContextValue);
 
-export const ReefKnot = ({
-  rpc,
-  chains,
-  walletDataList,
+export const ReefKnotProvider = ({
+  config,
   children,
 }: ReefKnotContextProps) => {
-  const contextValue = useMemo(
-    () => ({
-      rpc,
-      walletDataList,
-      chains,
-    }),
-    [rpc, walletDataList, chains],
-  );
-
   return (
-    <ReefKnotContext.Provider value={contextValue}>
+    <ReefKnotContext.Provider value={config}>
       <ReefKnotModalContextProvider>{children}</ReefKnotModalContextProvider>
     </ReefKnotContext.Provider>
   );


### PR DESCRIPTION
1. Rename ReefKnot to ReefKnotProvider
2. Change props – get only one config prop

`<ReefKnotProvider config={reefKnotConfig}>`
