### PR TITLE
refactor: removing reefknot config args rpc and chains because of no use

### DIFF
--- a/apps/demo-react/components/ConfigContextProviders.tsx
+++ b/apps/demo-react/components/ConfigContextProviders.tsx
@@ -35,8 +35,6 @@ const config = createConfig({
 const queryClient = new QueryClient();
 
 const reefKnotConfig = {
-  rpc: rpcUrlsString,
-  chains: SUPPORTED_CHAINS,
   walletDataList: walletsDataList,
 };
 

--- a/apps/demo-react/components/ProviderSDKWithProps.tsx
+++ b/apps/demo-react/components/ProviderSDKWithProps.tsx
@@ -7,7 +7,7 @@ import { ProviderSDK } from '@lido-sdk/react';
 
 import { mainnet } from 'wagmi/chains';
 import { getStaticRpcBatchProvider } from '@lido-sdk/providers';
-import { useReefKnotContext } from 'reef-knot/core-react';
+import { rpcUrlsString } from '../util/rpc';
 
 const POLLING_INTERVAL = 12_000;
 
@@ -20,7 +20,6 @@ export const ProviderSDKWithProps = (props: {
   const { supportedChains } = useSupportedChains();
   const config = useConfig();
   const client = useClient();
-  const { rpc } = useReefKnotContext();
 
   const [providerWeb3, setProviderWeb3] = useState<Web3Provider | undefined>();
 
@@ -71,19 +70,25 @@ export const ProviderSDKWithProps = (props: {
   );
 
   const providerRpc = useMemo(
-    () => getStaticRpcBatchProvider(chainId, rpc[chainId], 0, POLLING_INTERVAL),
-    [rpc, chainId],
+    () =>
+      getStaticRpcBatchProvider(
+        chainId,
+        rpcUrlsString[chainId],
+        0,
+        POLLING_INTERVAL,
+      ),
+    [chainId],
   );
 
   const providerMainnetRpc = useMemo(
     () =>
       getStaticRpcBatchProvider(
         mainnet.id,
-        rpc[mainnet.id],
+        rpcUrlsString[mainnet.id],
         0,
         POLLING_INTERVAL,
       ),
-    [rpc],
+    [],
   );
 
   return (

--- a/apps/demo-react/components/WalletsModal.tsx
+++ b/apps/demo-react/components/WalletsModal.tsx
@@ -17,7 +17,7 @@ export default function WalletsModal({
 }) {
   return (
     <ReefKnotWalletsModal<WalletIdsEthereum>
-      {...WALLETS_MODAL_DEFAULT_CONFIG}
+      {...walletsModalDefaultConfig}
       metrics={metrics}
       darkThemeEnabled={darkThemeEnabled}
       linkDontHaveWallet={LINK_DONT_HAVE_WALLET_DEFAULT}

--- a/packages/connect-wallet-modal/README.md
+++ b/packages/connect-wallet-modal/README.md
@@ -10,10 +10,10 @@ import type { WalletIdsEthereum } from '@reef-knot/wallets-list';
 
 Use it like this:
 ```tsx
-const WALLETS_MODAL_DEFAULT_CONFIG = getDefaultWalletsModalConfig();
+const walletsModalDefaultConfig = getDefaultWalletsModalConfig();
 
 <ReefKnotWalletsModal<WalletIdsEthereum>
-  {...WALLETS_MODAL_DEFAULT_CONFIG}
+  {...walletsModalDefaultConfig}
   darkThemeEnabled={false}
   walletsShown={[
     'metaMask',

--- a/packages/connect-wallet-modal/src/components/EagerConnectModal/EagerConnectModal.tsx
+++ b/packages/connect-wallet-modal/src/components/EagerConnectModal/EagerConnectModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useConfig } from 'wagmi';
 import { Button, Modal } from '@reef-knot/ui-react';
 import { CommonButtonsContainer, ErrorBlock } from './styles';
 import {
@@ -18,7 +19,7 @@ export const EagerConnectModal = ({
   children,
 }: AcceptTermsModalProps) => {
   const { termsChecked, closeModal } = useReefKnotModal();
-  const { chains: supportedChains } = useReefKnotContext();
+  const { chains: supportedChains } = useConfig();
 
   const [error, setError] = useState(initialError);
 

--- a/packages/core-react/src/context/reefKnot.tsx
+++ b/packages/core-react/src/context/reefKnot.tsx
@@ -1,12 +1,9 @@
 import React, { createContext, ReactNode, useMemo } from 'react';
 import { ReefKnotModalContextProvider } from './reefKnotModalContext';
-import type { Chain } from 'wagmi/chains';
 import type { WalletAdapterData } from '@reef-knot/types';
 
 export type ReefKnotProviderConfig = {
-  rpc: Record<number, string>;
   walletDataList: WalletAdapterData[];
-  chains: readonly [Chain, ...Chain[]];
 };
 
 export interface ReefKnotContextProps {


### PR DESCRIPTION
Removing rpc, chains props from ReefKnot provider because they are not used at all, so there is no need to configure and to store them.