### PR TITLE
Fix: Ledger Live Provider – add "request" method

### DIFF
--- a/packages/connectors/ledger-connector/CHANGELOG.md
+++ b/packages/connectors/ledger-connector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/ledger-connector
 
+## 4.1.1
+
+### Patch Changes
+
+- Fix: wrap IFrameEthereumProvider in LedgerIFrameProvider with the "request" method, which is required for useWalletClient wagmi hook
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ledger-connector",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connectors/ledger-connector/src/iframe/connector.ts
+++ b/packages/connectors/ledger-connector/src/iframe/connector.ts
@@ -13,10 +13,8 @@ import { Chain } from 'wagmi/chains';
 import { getAddress } from '@ethersproject/address';
 import { hexValue } from '@ethersproject/bytes';
 import { Web3Provider, ExternalProvider } from '@ethersproject/providers';
-import type {
-  IFrameEthereumProvider,
-  IFrameEthereumProviderOptions,
-} from '@ledgerhq/iframe-provider';
+import type { IFrameEthereumProviderOptions } from '@ledgerhq/iframe-provider';
+import type { LedgerIFrameProvider } from './provider';
 
 export const idLedgerLive = 'ledgerLive';
 export const name = 'Ledger Live';
@@ -31,9 +29,9 @@ export function ledgerLiveConnector({
   options,
   defaultChain,
 }: LedgerLiveConnectorArgs) {
-  const providers: Record<Chain['id'], IFrameEthereumProvider> = {};
+  const providers: Record<Chain['id'], LedgerIFrameProvider> = {};
 
-  return createConnector<IFrameEthereumProvider>(({ chains, emitter }) => ({
+  return createConnector<LedgerIFrameProvider>(({ chains, emitter }) => ({
     id: idLedgerLive,
     name,
     type: ledgerLiveConnector.type,
@@ -41,10 +39,8 @@ export function ledgerLiveConnector({
     async getProvider({ chainId } = {}) {
       const chain = chains.find((x) => x.id === chainId) ?? defaultChain;
       if (!providers[chain.id]) {
-        const { IFrameEthereumProvider } = await import(
-          '@ledgerhq/iframe-provider'
-        );
-        providers[chain.id] = new IFrameEthereumProvider(options);
+        const { LedgerIFrameProvider } = await import('./provider');
+        providers[chain.id] = new LedgerIFrameProvider(options);
       }
       return providers[chain.id];
     },

--- a/packages/connectors/ledger-connector/src/iframe/provider.ts
+++ b/packages/connectors/ledger-connector/src/iframe/provider.ts
@@ -1,7 +1,4 @@
-import {
-  IFrameEthereumProvider,
-  IFrameEthereumProviderOptions,
-} from '@ledgerhq/iframe-provider';
+import { IFrameEthereumProvider } from '@ledgerhq/iframe-provider';
 
 interface RequestArguments {
   readonly method: string;
@@ -9,13 +6,7 @@ interface RequestArguments {
 }
 
 export class LedgerIFrameProvider extends IFrameEthereumProvider {
-  constructor(options?: IFrameEthereumProviderOptions) {
-    super(options);
-  }
-
   request({ method, params }: RequestArguments) {
-    return this.sendAsync({ method, params }, (error) => {
-      if (error) console.error(error);
-    });
+    return this.send(method, params);
   }
 }

--- a/packages/connectors/ledger-connector/src/iframe/provider.ts
+++ b/packages/connectors/ledger-connector/src/iframe/provider.ts
@@ -1,0 +1,21 @@
+import {
+  IFrameEthereumProvider,
+  IFrameEthereumProviderOptions,
+} from '@ledgerhq/iframe-provider';
+
+interface RequestArguments {
+  readonly method: string;
+  readonly params?: any[];
+}
+
+export class LedgerIFrameProvider extends IFrameEthereumProvider {
+  constructor(options?: IFrameEthereumProviderOptions) {
+    super(options);
+  }
+
+  request({ method, params }: RequestArguments) {
+    return this.sendAsync({ method, params }, (error) => {
+      if (error) console.error(error);
+    });
+  }
+}

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,13 @@
 # reef-knot
 
+## 5.7.1
+
+### Patch Changes
+
+- Fix: wrap IFrameEthereumProvider in LedgerIFrameProvider with the "request" method, which is required for useWalletClient wagmi hook
+- Updated dependencies
+  - @reef-knot/ledger-connector@4.1.1
+
 ## 5.7.0
 
 ### Minor Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -48,7 +48,7 @@
     "@reef-knot/wallets-list": "2.3.0",
     "@reef-knot/wallets-helpers": "2.1.0",
     "@reef-knot/types": "2.1.0",
-    "@reef-knot/ledger-connector": "4.1.0"
+    "@reef-knot/ledger-connector": "4.1.1"
   },
   "peerDependencies": {
     "@lidofinance/lido-ui": "^3.18.0",


### PR DESCRIPTION
Fix: wrap `IFrameEthereumProvider` in `LedgerIFrameProvider` with the `request` method, which is required for `useWalletClient` wagmi hook