### PR TITLE
Use "tui" in turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "ui": "tui",
   "tasks": {
     "build": {
       "dependsOn": [


### PR DESCRIPTION
"tui" allows for viewing each log at once and interacting with the task. "stream" outputs logs as they come in and is not interactive.

Setting the option to "tui" because it is more convenient than the default option after updating turbo to v2.

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/5f875f46-a09e-4827-97f5-522a304b11f8">
