### PR TITLE
Feature/si 1594 ledger hid connection via low speed internet

### DIFF
--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerConnectionScreen.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerConnectionScreen.tsx
@@ -1,38 +1,22 @@
-import React from 'react';
-import {
-  Loader,
-  Stack,
-  StackItem,
-  Text,
-  useBreakpoint,
-} from '@lidofinance/lido-ui';
-import { LedgerImageDefault } from './icons/LedgerImageDefault';
-import { LedgerImageDefaultMobile } from './icons/LedgerImageDefaultMobile';
-import { LedgerScreenContainerStyled } from './styles';
+import React, { FC } from 'react';
+import { Loader } from '@lidofinance/lido-ui';
 import { useLedgerContext } from './hooks';
+import { LedgerModalScreen } from './LedgerModalScreen';
+import { LedgerImageDefaultAdaptive } from './icons/LedgerImageDefaultAdaptive';
 
 export const LedgerConnectionScreen = () => {
   const { isLoadingLedgerLibs } = useLedgerContext();
+
+  const message = isLoadingLedgerLibs ? (
+    <Loader size="medium" color="secondary" />
+  ) : (
+    'Please connect your Ledger and launch Ethereum app on your device'
+  );
+
   return (
-    <LedgerScreenContainerStyled>
-      <Stack direction="column" spacing="xl" align="center">
-        <StackItem>
-          {useBreakpoint('md') ? (
-            <LedgerImageDefaultMobile />
-          ) : (
-            <LedgerImageDefault />
-          )}
-        </StackItem>
-        <StackItem>
-          {isLoadingLedgerLibs ? (
-            <Loader size="medium" color="secondary" />
-          ) : (
-            <Text color="secondary" size="xs">
-              Please connect your Ledger and launch Ethereum app on your device
-            </Text>
-          )}
-        </StackItem>
-      </Stack>
-    </LedgerScreenContainerStyled>
+    <LedgerModalScreen
+      icon={<LedgerImageDefaultAdaptive />}
+      message={message}
+    />
   );
 };

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerConnectionScreen.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerConnectionScreen.tsx
@@ -4,7 +4,15 @@ import { useLedgerContext } from './hooks';
 import { LedgerModalScreen } from './LedgerModalScreen';
 import { LedgerImageDefaultAdaptive } from './icons/LedgerImageDefaultAdaptive';
 
-export const LedgerConnectionScreen = () => {
+type LedgerConnectionScreenProps = {
+  showConnectButton?: boolean;
+  onClickConnect?: () => void;
+};
+
+export const LedgerConnectionScreen: FC<LedgerConnectionScreenProps> = ({
+  showConnectButton,
+  onClickConnect,
+}) => {
   const { isLoadingLedgerLibs } = useLedgerContext();
 
   const message = isLoadingLedgerLibs ? (
@@ -17,6 +25,8 @@ export const LedgerConnectionScreen = () => {
     <LedgerModalScreen
       icon={<LedgerImageDefaultAdaptive />}
       message={message}
+      action={showConnectButton ? 'Connect' : undefined}
+      onClickAction={showConnectButton ? onClickConnect : undefined}
     />
   );
 };

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerContext.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerContext.tsx
@@ -13,7 +13,7 @@ import type Transport from '@ledgerhq/hw-transport';
 import { helpers } from '@reef-knot/web3-react';
 import { getTransport, isHIDSupported } from './helpers';
 
-const USER_ACTIVATION_TIMEOUT = 5000;
+const USER_ACTIVATION_TIMEOUT = 3000;
 
 type EthConstructorType = new (
   ...args: ConstructorParameters<typeof Eth>

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerErrorScreen.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerErrorScreen.tsx
@@ -1,50 +1,21 @@
 import React, { FC } from 'react';
-import {
-  Text,
-  Button,
-  Stack,
-  StackItem,
-  useBreakpoint,
-} from '@lidofinance/lido-ui';
-import styled from '@reef-knot/ui-react/styled-wrapper';
-import { LedgerScreenContainerStyled } from './styles';
-import { LedgerImageError } from './icons/LedgerImageError';
-import { LedgerImageErrorMobile } from './icons/LedgerImageErrorMobile';
+import { LedgerModalScreen } from './LedgerModalScreen';
+import { LedgerImageErrorAdaptive } from './icons/LedgerImageErrorAdaptive';
 
-const HeadingStyled = styled(Text)`
-  padding-bottom: 4px;
-`;
+type LedgerErrorScreenProps = {
+  message: React.ReactNode;
+  onClickRetry: () => void;
+};
 
-export const LedgerErrorScreen: FC<{ message: string; retry: () => void }> = ({
+export const LedgerErrorScreen: FC<LedgerErrorScreenProps> = ({
   message,
-  retry,
+  onClickRetry,
 }) => (
-  <LedgerScreenContainerStyled>
-    <Stack direction="column" spacing="xl" align="stretch">
-      <StackItem>
-        <Stack direction="column" spacing="xl" align="center">
-          <StackItem>
-            {useBreakpoint('md') ? (
-              <LedgerImageErrorMobile />
-            ) : (
-              <LedgerImageError />
-            )}
-          </StackItem>
-          <StackItem>
-            <HeadingStyled color="default" size="sm" strong>
-              Something went wrong
-            </HeadingStyled>
-            <Text color="secondary" size="xs">
-              {message}
-            </Text>
-          </StackItem>
-        </Stack>
-      </StackItem>
-      <StackItem>
-        <Button variant="ghost" fullwidth onClick={retry}>
-          Retry
-        </Button>
-      </StackItem>
-    </Stack>
-  </LedgerScreenContainerStyled>
+  <LedgerModalScreen
+    icon={<LedgerImageErrorAdaptive />}
+    heading="Something went wrong"
+    message={message}
+    action="Retry"
+    onClickAction={onClickRetry}
+  />
 );

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerModal.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerModal.tsx
@@ -33,21 +33,34 @@ export const LedgerModal = (props: LedgerModalProps) => {
 };
 
 export const LedgerScreen = ({ metrics, onClose }: LedgerModalProps) => {
-  const { error, reconnectTransport, isTransportConnected } =
-    useLedgerContext();
+  const {
+    error,
+    reconnectTransport,
+    isTransportConnected,
+    isUserActivationRequired,
+  } = useLedgerContext();
+
+  const handleClickRetry = useCallback(() => {
+    void reconnectTransport();
+  }, [reconnectTransport]);
 
   return (
     <LedgerModalInnerContainer>
       {error && (
         <LedgerErrorScreen
           message={error.message}
-          retry={() => void reconnectTransport()}
+          onClickRetry={handleClickRetry}
         />
       )}
       {!error && isTransportConnected && (
         <LedgerAccountScreen metrics={metrics} closeScreen={onClose} />
       )}
-      {!error && !isTransportConnected && <LedgerConnectionScreen />}
+      {!error && !isTransportConnected && (
+        <LedgerConnectionScreen
+          showConnectButton={isUserActivationRequired}
+          onClickConnect={handleClickRetry}
+        />
+      )}
     </LedgerModalInnerContainer>
   );
 };

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerModalScreen.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerModalScreen.tsx
@@ -1,0 +1,53 @@
+import React, { FC } from 'react';
+import { Text, Button, Stack, StackItem } from '@lidofinance/lido-ui';
+import styled from '@reef-knot/ui-react/styled-wrapper';
+import { LedgerScreenContainerStyled } from './styles';
+
+const HeadingStyled = styled(Text)`
+  padding-bottom: 4px;
+`;
+
+type LedgerActionScreenProps = {
+  icon: React.ReactNode;
+  heading?: React.ReactNode;
+  message?: React.ReactNode;
+  action?: React.ReactNode;
+  onClickAction?: () => void;
+};
+
+export const LedgerModalScreen: FC<LedgerActionScreenProps> = ({
+  icon,
+  heading,
+  message,
+  action,
+  onClickAction,
+}) => (
+  <LedgerScreenContainerStyled>
+    <Stack direction="column" spacing="xl" align="stretch">
+      <StackItem>
+        <Stack direction="column" spacing="xl" align="center">
+          <StackItem>{icon}</StackItem>
+          <StackItem>
+            {heading && (
+              <HeadingStyled color="default" size="sm" strong>
+                {heading}
+              </HeadingStyled>
+            )}
+            {message && (
+              <Text color="secondary" size="xs">
+                {message}
+              </Text>
+            )}
+          </StackItem>
+        </Stack>
+      </StackItem>
+      {action && (
+        <StackItem>
+          <Button variant="ghost" fullwidth onClick={onClickAction}>
+            {action}
+          </Button>
+        </StackItem>
+      )}
+    </Stack>
+  </LedgerScreenContainerStyled>
+);

--- a/packages/connect-wallet-modal/src/components/Ledger/icons/LedgerImageDefaultAdaptive.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/icons/LedgerImageDefaultAdaptive.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useBreakpoint } from '@lidofinance/lido-ui';
+import { LedgerImageDefault } from './LedgerImageDefault';
+import { LedgerImageDefaultMobile } from './LedgerImageDefaultMobile';
+
+export const LedgerImageDefaultAdaptive = () => {
+  return useBreakpoint('md') ? (
+    <LedgerImageDefaultMobile />
+  ) : (
+    <LedgerImageDefault />
+  );
+};

--- a/packages/connect-wallet-modal/src/components/Ledger/icons/LedgerImageErrorAdaptive.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/icons/LedgerImageErrorAdaptive.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { useBreakpoint } from '@lidofinance/lido-ui';
+import { LedgerImageError } from './LedgerImageError';
+import { LedgerImageErrorMobile } from './LedgerImageErrorMobile';
+
+export const LedgerImageErrorAdaptive = () => {
+  return useBreakpoint('md') ? (
+    <LedgerImageErrorMobile />
+  ) : (
+    <LedgerImageError />
+  );
+};


### PR DESCRIPTION
### Description
There is an issue if the ledger packages loading takes too long (~ >5 sec): a user will see a connection error immediately after packages were loaded. That happens because of browser protection mechanism called User Activation.

Suggestion: Measure the time it took to download the Ledger packages. If it took >3s, show an additional "Connect" button in the Ledger modal instead of trying to connect right away.

### Testing notes

1. Enable "Slow 4g" throttling option
2. Click "Ledger" connect button
3. Huge ledger packages are starting to load, it takes >5 seconds
4. Ledger packages are finished loading. There was an error before on this stage. Now it should show "Connect" button, which when being clicked confirms user intention for the browser.

### Demo

<img width="495" alt="image" src="https://github.com/user-attachments/assets/8cd20bbd-1263-4f63-960b-b11c653b5425">

