### PR TITLE
refactor: metrics replaced with action callback props

### DIFF
--- a/apps/demo-react/providers/web3.tsx
+++ b/apps/demo-react/providers/web3.tsx
@@ -11,7 +11,7 @@ import {
   getDefaultWalletsModalConfig,
 } from 'reef-knot/connect-wallet-modal';
 
-import metrics from 'utils/metrics';
+import { metricProps } from 'utils/metrics';
 import { useClientConfig } from 'providers/client-config';
 import { useRpcUrls } from 'hooks/useRpcUrls';
 
@@ -77,7 +77,7 @@ const Web3Provider: FC<PropsWithChildren> = ({ children }) => {
       // Wallets config args
       // TODO: We could call `getDefaultWalletsModalConfig` inside `getDefaultConfig`, but it cause package dependency cycle rn
       ...getDefaultWalletsModalConfig(),
-      metrics,
+      ...metricProps,
       linkDontHaveWallet: LINK_DONT_HAVE_WALLET,
     });
   }, [

--- a/apps/demo-react/utils/metrics.ts
+++ b/apps/demo-react/utils/metrics.ts
@@ -1,57 +1,22 @@
 /* eslint-disable no-console */
-import type { MetricsProp } from '@reef-knot/types';
+import type { ReefKnotWalletsModalConfig } from '@reef-knot/types';
 import type { WalletIdsEthereum } from '@reef-knot/wallets-list';
 
-const getClickHandler = (walletName: string) => () =>
-  console.log(`metrics: ${walletName} clicked`);
+type MetricProps = Pick<
+  ReefKnotWalletsModalConfig<WalletIdsEthereum>,
+  | 'onClickTermsAccept'
+  | 'onClickWalletsMore'
+  | 'onClickWalletsLess'
+  | 'onConnectStart'
+  | 'onConnectSuccess'
+>;
 
-const getConnectHandler = (walletName: string) => () =>
-  console.log(`metrics: ${walletName} connected`);
-
-const metrics: MetricsProp<WalletIdsEthereum> = {
-  events: {
-    click: {
-      handlers: {
-        walletsMore: getClickHandler('More Wallets'),
-        walletsLess: getClickHandler('Less Wallets'),
-        termsAccept: getClickHandler('Terms'),
-        ambire: getClickHandler('ambire'),
-        brave: getClickHandler('brave'),
-        coin98: getClickHandler('coin98'),
-        coinbase: getClickHandler('coinbase'),
-        exodus: getClickHandler('exodus'),
-        imToken: getClickHandler('imToken'),
-        ledgerHID: getClickHandler('ledgerHID'),
-        metaMask: getClickHandler('metaMask'),
-        trust: getClickHandler('trust'),
-        walletConnect: getClickHandler('walletConnect'),
-        xdefi: getClickHandler('xdefi'),
-        okx: getClickHandler('okx'),
-        bitget: getClickHandler('bitget'),
-        browserExtension: getClickHandler('browserExtension'),
-        binanceWallet: getClickHandler('binanceWallet'),
-      },
-    },
-    connect: {
-      handlers: {
-        ambire: getConnectHandler('ambire'),
-        brave: getConnectHandler('brave'),
-        coin98: getConnectHandler('coin98'),
-        coinbase: getConnectHandler('coinbase'),
-        exodus: getConnectHandler('exodus'),
-        imToken: getConnectHandler('imToken'),
-        ledgerHID: getConnectHandler('ledgerHID'),
-        metaMask: getConnectHandler('metaMask'),
-        trust: getConnectHandler('trust'),
-        walletConnect: getConnectHandler('walletConnect'),
-        xdefi: getConnectHandler('xdefi'),
-        okx: getConnectHandler('okx'),
-        bitget: getConnectHandler('bitget'),
-        browserExtension: getConnectHandler('browserExtension'),
-        binanceWallet: getConnectHandler('binanceWallet'),
-      },
-    },
+export const metricProps: MetricProps = {
+  onClickTermsAccept: (isAccepted) => {
+    if (isAccepted) console.log(`metrics: terms accept clicked`);
   },
+  onClickWalletsMore: () => console.log(`metrics: more wallets clicked`),
+  onClickWalletsLess: () => console.log(`metrics: less wallets clicked`),
+  onConnectStart: (walletId) => console.log(`metrics: ${walletId} clicked`),
+  onConnectSuccess: (walletId) => console.log(`metrics: ${walletId} connected`),
 };
-
-export default metrics;

--- a/apps/demo-react/utils/metrics.ts
+++ b/apps/demo-react/utils/metrics.ts
@@ -12,11 +12,12 @@ type MetricProps = Pick<
 >;
 
 export const metricProps: MetricProps = {
-  onClickTermsAccept: (isAccepted) => {
+  onClickTermsAccept: ({ isAccepted }) => {
     if (isAccepted) console.log(`metrics: terms accept clicked`);
   },
   onClickWalletsMore: () => console.log(`metrics: more wallets clicked`),
   onClickWalletsLess: () => console.log(`metrics: less wallets clicked`),
-  onConnectStart: (walletId) => console.log(`metrics: ${walletId} clicked`),
-  onConnectSuccess: (walletId) => console.log(`metrics: ${walletId} connected`),
+  onConnectStart: ({ walletId }) => console.log(`metrics: ${walletId} clicked`),
+  onConnectSuccess: ({ walletId }) =>
+    console.log(`metrics: ${walletId} connected`),
 };

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @reef-knot/connect-wallet-modal
 
+## 7.0.0
+
+### Major Changes
+
+- Metrics config refactored, replaced with certain actions callbacks
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/core-react@6.0.0
+  - @reef-knot/types@4.0.0
+  - @reef-knot/web3-react@6.0.0
+  - @reef-knot/wallets-list@4.0.0
+
 ## 6.0.2
 
 ### Patch Changes

--- a/packages/connect-wallet-modal/README.md
+++ b/packages/connect-wallet-modal/README.md
@@ -38,5 +38,5 @@ const walletsModalDefaultConfig = getDefaultWalletsModalConfig();
 | `config.walletsShown` | Controls displayed wallet connection buttons from the list of wallets in the modal. Wallets will be displayed in the specified sequence. <br /> ***Default**: Get with `getDefaultWalletsModalConfig()`* |
 | `config.walletsPinned` | Pins certain wallets to display it at the top of the list. <br /> ***Default**: Get with `getDefaultWalletsModalConfig()`* |
 | `config.walletsDisplayInitialCount?` | Connection buttons count to render before the "More wallets" button. <br /> ***Default**: `6`* |
-| `config.metrics` | A map of the analytic events. |
+| `config.onClickTermsAccept({ isAccepted })` <br /> `config.onClickWalletsMore()` <br /> `config.onClickWalletsLess()` <br /> `config.onConnectStart({ walletId })` <br /> `config.onConnectSuccess({ walletId })` | Event callbacks. |
 | `config.linkTerms?` <br /> `config.linkPrivacyNotice?` <br /> `config.linkDontHaveWallet?` | UI links. |

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,16 +41,16 @@
     "@ledgerhq/hw-app-eth": "^6.37.1",
     "@ledgerhq/hw-transport-webhid": "^6.29.0",
     "@lidofinance/lido-ui": "^3.18.0",
-    "@reef-knot/wallets-list": "^3.0.0",
+    "@reef-knot/wallets-list": "^4.0.0",
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.17"
   },
   "devDependencies": {
-    "@reef-knot/core-react": "^5.0.0",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/core-react": "^6.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ui-react": "^2.1.5",
     "@reef-knot/wallets-helpers": "^2.1.1",
-    "@reef-knot/web3-react": "^5.0.0",
+    "@reef-knot/web3-react": "^6.0.0",
     "@reef-knot/ledger-connector": "^4.1.4",
     "eslint-config-custom": "*",
     "react": "18.2.0",
@@ -59,11 +59,11 @@
     "wagmi": ">=2.12"
   },
   "peerDependencies": {
-    "@reef-knot/core-react": "^5.0.0",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/core-react": "^6.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ui-react": "^2.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
-    "@reef-knot/web3-react": "^5.0.0",
+    "@reef-knot/web3-react": "^6.0.0",
     "@reef-knot/ledger-connector": "^4.0.0",
     "react": ">=18",
     "@lidofinance/lido-ui": "^3.18.0",

--- a/packages/connect-wallet-modal/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/packages/connect-wallet-modal/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -25,11 +25,14 @@ export const ConnectWalletModal = ({
 }: ConnectWalletModalProps) => {
   const { config: modalConfig, darkThemeEnabled = false } = passedDownProps;
   const {
-    metrics,
     buttonComponentsByConnectorId,
     walletsShown,
     walletsPinned,
     walletsDisplayInitialCount = 6,
+    onConnectStart,
+    onConnectSuccess,
+    onClickWalletsMore,
+    onClickWalletsLess,
   } = modalConfig;
 
   const config = useConfig();
@@ -50,17 +53,15 @@ export const ConnectWalletModal = ({
     setInputValue('');
   }, []);
 
-  const { walletsMore, walletsLess } = metrics?.events?.click?.handlers || {};
-
   const handleToggleWalletsList = useCallback(() => {
     const nextShownState = !isShownOtherWallets;
     setShowOtherWallets(nextShownState);
     if (nextShownState) {
-      walletsMore?.();
+      onClickWalletsMore?.();
     } else {
-      walletsLess?.();
+      onClickWalletsLess?.();
     }
-  }, [isShownOtherWallets, walletsMore, walletsLess]);
+  }, [isShownOtherWallets, onClickWalletsMore, onClickWalletsLess]);
 
   const [walletsListFull, setWalletsListFull] = useState<WalletAdapterData[]>(
     [],
@@ -70,8 +71,9 @@ export const ConnectWalletModal = ({
     (walletId: string) => {
       void config.storage?.setItem(LS_KEY_RECONNECT_WALLET_ID, walletId);
       onCloseSuccess?.();
+      onConnectSuccess?.(walletId);
     },
-    [onCloseSuccess, config.storage],
+    [onCloseSuccess, onConnectSuccess, config.storage],
   );
 
   useEffect(() => {
@@ -144,15 +146,15 @@ export const ConnectWalletModal = ({
             walletId={walletId}
             walletName={walletData.walletName}
             disabled={!termsChecked || someWalletIsLoading}
-            onConnect={() => handleConnectSuccess(walletId)}
             darkThemeEnabled={darkThemeEnabled}
-            metrics={metrics}
             isCompact={isShownOtherWallets}
             connector={walletData.createConnectorFn}
             detector={walletData.detector}
             deeplink={walletData.deeplink}
             downloadURLs={walletData.downloadURLs}
             walletconnectExtras={walletData.walletconnectExtras}
+            onConnectStart={() => onConnectStart?.(walletId)}
+            onConnectSuccess={() => handleConnectSuccess(walletId)}
           />
         );
       })}

--- a/packages/connect-wallet-modal/src/components/ConnectWalletModal/ConnectWalletModal.tsx
+++ b/packages/connect-wallet-modal/src/components/ConnectWalletModal/ConnectWalletModal.tsx
@@ -71,7 +71,7 @@ export const ConnectWalletModal = ({
     (walletId: string) => {
       void config.storage?.setItem(LS_KEY_RECONNECT_WALLET_ID, walletId);
       onCloseSuccess?.();
-      onConnectSuccess?.(walletId);
+      onConnectSuccess?.({ walletId });
     },
     [onCloseSuccess, onConnectSuccess, config.storage],
   );
@@ -153,7 +153,7 @@ export const ConnectWalletModal = ({
             deeplink={walletData.deeplink}
             downloadURLs={walletData.downloadURLs}
             walletconnectExtras={walletData.walletconnectExtras}
-            onConnectStart={() => onConnectStart?.(walletId)}
+            onConnectStart={() => onConnectStart?.({ walletId })}
             onConnectSuccess={() => handleConnectSuccess(walletId)}
           />
         );

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerModal.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerModal.tsx
@@ -5,34 +5,41 @@ import { LedgerContextProvider } from './LedgerContext';
 import { LedgerErrorScreen } from './LedgerErrorScreen';
 import { useLedgerContext } from './hooks';
 import { LedgerAccountScreen } from './LedgerAccountScreen';
-import type { MetricsProp } from '../ReefKnotWalletsModal';
 import { LedgerModalInnerContainer } from './styles';
 
 export type LedgerModalProps = ModalProps & {
-  metrics?: MetricsProp;
+  onCloseSuccess?: () => void;
+  onCloseReject?: () => void;
 };
 
-export const LedgerModal = (props: LedgerModalProps) => {
-  const { onClose } = props;
+export const LedgerModal = ({
+  onCloseSuccess,
+  onCloseReject,
+  ...props
+}: LedgerModalProps) => {
   const handleClose = useCallback(
     (event?: any) => {
       // hack needed to prevent the Modal closing on Select
       if (!event) return;
-      onClose?.();
+      onCloseReject?.();
     },
-    [onClose],
+    [onCloseReject],
   );
 
   return (
     <Modal title="Ledger connect" {...props} onClose={handleClose}>
       <LedgerContextProvider isActive={!!props.open}>
-        <LedgerScreen {...props} />
+        <LedgerScreen
+          onCloseSuccess={onCloseSuccess}
+          onCloseReject={onCloseReject}
+          {...props}
+        />
       </LedgerContextProvider>
     </Modal>
   );
 };
 
-export const LedgerScreen = ({ metrics, onClose }: LedgerModalProps) => {
+export const LedgerScreen = ({ onCloseSuccess }: LedgerModalProps) => {
   const { error, reconnectTransport, isTransportConnected } =
     useLedgerContext();
 
@@ -45,7 +52,7 @@ export const LedgerScreen = ({ metrics, onClose }: LedgerModalProps) => {
         />
       )}
       {!error && isTransportConnected && (
-        <LedgerAccountScreen metrics={metrics} closeScreen={onClose} />
+        <LedgerAccountScreen onConnectSuccess={onCloseSuccess} />
       )}
       {!error && !isTransportConnected && <LedgerConnectionScreen />}
     </LedgerModalInnerContainer>

--- a/packages/connect-wallet-modal/src/components/ReefKnotWalletsModal/ReefKnotWalletsModal.tsx
+++ b/packages/connect-wallet-modal/src/components/ReefKnotWalletsModal/ReefKnotWalletsModal.tsx
@@ -31,7 +31,8 @@ export function ReefKnotWalletsModal<I extends string = string>(
         <LedgerModal
           {...props} // the props are overridden here on purpose
           open
-          onClose={onCloseSuccess}
+          onCloseSuccess={onCloseSuccess}
+          onCloseReject={onCloseReject}
           onBack={onCloseReject}
           onExited={onExit}
         />

--- a/packages/connect-wallet-modal/src/components/Terms/Terms.tsx
+++ b/packages/connect-wallet-modal/src/components/Terms/Terms.tsx
@@ -14,9 +14,10 @@ export const Terms: FC<TermsProps> = ({ config }) => {
 
   const handleCheckboxChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setTermsChecked(e.currentTarget.checked);
-      if (e.target.checked) {
-        onClickTermsAccept?.(e.target.checked);
+      const isAccepted = e.currentTarget.checked;
+      setTermsChecked(isAccepted);
+      if (isAccepted) {
+        onClickTermsAccept?.({ isAccepted });
       }
     },
     [setTermsChecked, onClickTermsAccept],

--- a/packages/connect-wallet-modal/src/components/Terms/Terms.tsx
+++ b/packages/connect-wallet-modal/src/components/Terms/Terms.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
+import React, { ChangeEvent, FC, useCallback } from 'react';
 import { Checkbox, Link } from '@reef-knot/ui-react';
 import { useReefKnotModal } from '@reef-knot/core-react';
 import type { ReefKnotWalletsModalConfig } from '@reef-knot/types';
@@ -9,18 +9,18 @@ export type TermsProps = {
 };
 
 export const Terms: FC<TermsProps> = ({ config }) => {
-  const { metrics, linkTerms, linkPrivacyNotice } = config;
-
+  const { linkTerms, linkPrivacyNotice, onClickTermsAccept } = config;
   const { setTermsChecked, termsChecked } = useReefKnotModal();
-  const onClickTermsAccept =
-    metrics?.events?.click?.handlers.onClickTermsAccept;
 
-  const handleCheckboxChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setTermsChecked(e.currentTarget.checked);
-    if (e.target.checked) {
-      onClickTermsAccept?.();
-    }
-  };
+  const handleCheckboxChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setTermsChecked(e.currentTarget.checked);
+      if (e.target.checked) {
+        onClickTermsAccept?.(e.target.checked);
+      }
+    },
+    [setTermsChecked, onClickTermsAccept],
+  );
 
   return (
     <TermsStyle>

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectBinance.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectBinance.tsx
@@ -10,9 +10,7 @@ export const ConnectBinance: FC<ConnectInjectedProps> = (
   props: ConnectInjectedProps,
 ) => {
   const {
-    onConnect,
     darkThemeEnabled,
-    metrics,
     walletId,
     walletName,
     icon: WalletIcon,
@@ -20,37 +18,34 @@ export const ConnectBinance: FC<ConnectInjectedProps> = (
     detector,
     connector,
     deeplink,
+    onConnectStart,
+    onConnectSuccess,
     ...rest
   } = props;
-
-  const metricsOnConnect = metrics?.events?.connect?.handlers[walletId];
-  const metricsOnClick = metrics?.events?.click?.handlers[walletId];
 
   const { loadingWalletId } = useReefKnotContext();
   const { connectWithLoading } = useConnectWithLoading();
   const { disconnect } = useDisconnect();
 
   const handleConnect = useCallback(async () => {
-    metricsOnClick?.();
+    onConnectStart?.();
     disconnect?.();
 
     if (isMobileOrTablet && deeplink && !detector?.()) {
       openWindow(deeplink);
     } else {
       await connectWithLoading(walletId, { connector });
-      onConnect?.();
-      metricsOnConnect?.();
+      onConnectSuccess?.();
     }
   }, [
-    metricsOnClick,
     disconnect,
     deeplink,
     detector,
     connectWithLoading,
     walletId,
     connector,
-    onConnect,
-    metricsOnConnect,
+    onConnectStart,
+    onConnectSuccess,
   ]);
 
   return (

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectBrowser.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectBrowser.tsx
@@ -10,20 +10,18 @@ export const ConnectBrowser: FC<ConnectInjectedProps> = (
   props: ConnectInjectedProps,
 ) => {
   const {
-    onConnect,
     darkThemeEnabled,
-    metrics,
     walletId,
     walletName,
     icon: WalletIcon,
     connector,
+    onConnectStart,
+    onConnectSuccess,
     ...rest
   } = props;
   const { openModalAsync } = useReefKnotModal();
 
   const web3ProviderIsDetected = !!globalThis.window?.ethereum;
-  const metricsOnConnect = metrics?.events?.connect?.handlers[walletId];
-  const metricsOnClick = metrics?.events?.click?.handlers[walletId];
 
   const { connectAsync } = useConnect();
   const { disconnect } = useDisconnect();
@@ -32,13 +30,12 @@ export const ConnectBrowser: FC<ConnectInjectedProps> = (
     (WalletIcon as ElementType) || (WalletIcon as WalletAdapterIcons)?.light;
 
   const handleConnect = useCallback(async () => {
-    metricsOnClick?.();
+    onConnectStart?.();
 
     if (web3ProviderIsDetected) {
       disconnect?.();
       await connectAsync({ connector });
-      onConnect?.();
-      metricsOnConnect?.();
+      onConnectSuccess?.();
     } else {
       await openModalAsync({
         type: 'requirements',
@@ -57,11 +54,10 @@ export const ConnectBrowser: FC<ConnectInjectedProps> = (
     connectAsync,
     connector,
     disconnect,
-    metricsOnClick,
     openModalAsync,
     web3ProviderIsDetected,
-    onConnect,
-    metricsOnConnect,
+    onConnectStart,
+    onConnectSuccess,
   ]);
 
   return (

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectCoinbase.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectCoinbase.tsx
@@ -8,44 +8,33 @@ export const ConnectCoinbase: FC<ConnectInjectedProps> = (
   props: ConnectInjectedProps,
 ) => {
   const {
-    onConnect,
     darkThemeEnabled,
-    metrics,
     walletId,
     walletName,
     icon: WalletIcon,
     downloadURLs,
     detector,
     connector,
+    onConnectStart,
+    onConnectSuccess,
     ...rest
   } = props;
-
-  const metricsOnConnect = metrics?.events?.connect?.handlers[walletId];
-  const metricsOnClick = metrics?.events?.click?.handlers[walletId];
 
   const { connect } = useConnect();
   const { disconnect } = useDisconnect();
 
   const handleConnect = useCallback(() => {
-    metricsOnClick?.();
+    onConnectStart?.();
     disconnect?.();
     connect(
       { connector },
       {
         onSuccess: () => {
-          onConnect?.();
-          metricsOnConnect?.();
+          onConnectSuccess?.();
         },
       },
     );
-  }, [
-    connect,
-    connector,
-    disconnect,
-    metricsOnClick,
-    onConnect,
-    metricsOnConnect,
-  ]);
+  }, [connect, connector, disconnect, onConnectStart, onConnectSuccess]);
 
   return (
     <ConnectButtonBase

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectInjected.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectInjected.tsx
@@ -11,9 +11,7 @@ export const ConnectInjected: FC<ConnectInjectedProps> = (
   props: ConnectInjectedProps,
 ) => {
   const {
-    onConnect,
     darkThemeEnabled,
-    metrics,
     walletId,
     walletName,
     icon: WalletIcon,
@@ -21,22 +19,21 @@ export const ConnectInjected: FC<ConnectInjectedProps> = (
     detector,
     connector,
     deeplink,
+    onConnectStart,
+    onConnectSuccess,
     ...rest
   } = props;
-  const metricsOnConnect = metrics?.events?.connect?.handlers[walletId];
-  const metricsOnClick = metrics?.events?.click?.handlers[walletId];
 
   const { connectAsync } = useConnect();
   const { disconnect } = useDisconnect();
 
   const handleConnect = useCallback(async () => {
-    metricsOnClick?.();
+    onConnectStart?.();
 
     if (await detector?.()) {
       disconnect?.();
       await connectAsync({ connector });
-      onConnect?.();
-      metricsOnConnect?.();
+      onConnectSuccess?.();
     } else if (isMobileOrTablet && deeplink) {
       openWindow(deeplink);
     } else if (downloadURLs) {
@@ -49,9 +46,8 @@ export const ConnectInjected: FC<ConnectInjectedProps> = (
     detector,
     disconnect,
     downloadURLs,
-    metricsOnClick,
-    onConnect,
-    metricsOnConnect,
+    onConnectStart,
+    onConnectSuccess,
   ]);
 
   return (

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectLedger.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectLedger.tsx
@@ -6,21 +6,20 @@ import { useReefKnotModal } from '@reef-knot/core-react';
 export const ConnectLedger: FC<ConnectLedgerProps> = (props) => {
   const {
     walletId,
-    onConnect,
     darkThemeEnabled,
     icon: WalletIcon,
-    metrics,
+    onConnectStart,
+    onConnectSuccess,
     ...rest
   } = props;
 
   const { openModalAsync } = useReefKnotModal();
-  const metricsOnClick = metrics?.events?.click?.handlers[walletId];
 
   const handleConnect = useCallback(async () => {
-    metricsOnClick?.();
+    onConnectStart?.();
     const result = await openModalAsync({ type: 'ledger' });
-    if (result.success) onConnect?.();
-  }, [openModalAsync, onConnect, metricsOnClick]);
+    if (result.success) onConnectSuccess?.();
+  }, [openModalAsync, onConnectStart, onConnectSuccess]);
 
   return (
     <ConnectButtonBase

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectWC.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectWC.tsx
@@ -23,9 +23,7 @@ const setRedirectionWindowLocation = (redirectLink: string, WCURI: string) => {
 
 export const ConnectWC: FC<ConnectWCProps> = (props: ConnectWCProps) => {
   const {
-    onConnect,
     darkThemeEnabled,
-    metrics,
     walletId,
     walletName,
     icon: WalletIcon,
@@ -33,11 +31,10 @@ export const ConnectWC: FC<ConnectWCProps> = (props: ConnectWCProps) => {
     connector,
     walletconnectExtras,
     deeplink,
+    onConnectStart,
+    onConnectSuccess,
     ...rest
   } = props;
-
-  const metricsOnConnect = metrics?.events?.connect?.handlers[walletId];
-  const metricsOnClick = metrics?.events?.click?.handlers[walletId];
 
   const config = useConfig();
   const { loadingWalletId } = useReefKnotContext();
@@ -61,12 +58,11 @@ export const ConnectWC: FC<ConnectWCProps> = (props: ConnectWCProps) => {
       return; // A user was redirected to a wallet mobile app, no need to continue
     }
 
-    metricsOnClick?.();
+    onConnectStart?.();
     disconnect?.();
 
     const onSuccess = () => {
-      onConnect?.();
-      metricsOnConnect?.();
+      onConnectSuccess?.();
     };
 
     if (WCURICondition && WCURIConnectorFn && WCURIRedirectLink) {
@@ -104,13 +100,12 @@ export const ConnectWC: FC<ConnectWCProps> = (props: ConnectWCProps) => {
   }, [
     deeplink,
     disconnect,
-    metricsOnClick,
     WCURICloseRedirectionWindow,
     WCURICondition,
     WCURIConnectorFn,
     WCURIRedirectLink,
-    onConnect,
-    metricsOnConnect,
+    onConnectStart,
+    onConnectSuccess,
     connectAsync,
     config.chains,
     connectWithLoading,

--- a/packages/core-react/CHANGELOG.md
+++ b/packages/core-react/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @reef-knot/core-react
 
+## 6.0.0
+
+### Major Changes
+
+- Metrics config refactored, replaced with certain actions callbacks
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+  - @reef-knot/wallets-list@4.0.0
+
 ## 5.1.0
 
 ### Minor Changes

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/core-react",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "@reef-knot/ledger-connector": "^4.1.4",
-    "@reef-knot/wallets-list": "^3.0.0",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/wallets-list": "^4.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ui-react": "^2.1.5",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "eslint-config-custom": "*",
@@ -50,8 +50,8 @@
   },
   "peerDependencies": {
     "@reef-knot/ledger-connector": "^4.1.0",
-    "@reef-knot/wallets-list": "^3.0.0",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/wallets-list": "^4.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ui-react": "^2.1.3",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "react": ">=18",

--- a/packages/core-react/src/helpers/getDefaultConfig.ts
+++ b/packages/core-react/src/helpers/getDefaultConfig.ts
@@ -49,13 +49,17 @@ export const getDefaultConfig = <I extends string = string>({
 
   // Wallets config args
   buttonComponentsByConnectorId,
-  metrics,
   walletsShown,
   walletsPinned,
   walletsDisplayInitialCount,
   linkTerms,
   linkPrivacyNotice,
   linkDontHaveWallet,
+  onClickTermsAccept,
+  onClickWalletsLess,
+  onClickWalletsMore,
+  onConnectStart,
+  onConnectSuccess,
 
   // Wagmi config args
   ...wagmiArgs
@@ -83,13 +87,17 @@ export const getDefaultConfig = <I extends string = string>({
   // TODO: We could use `getDefaultWalletsModalConfig` here, but it cause package dependency cycle rn
   const walletsModalConfig: ReefKnotWalletsModalConfig = {
     buttonComponentsByConnectorId,
-    metrics,
     walletsShown,
     walletsPinned,
     walletsDisplayInitialCount,
     linkTerms,
     linkPrivacyNotice,
     linkDontHaveWallet,
+    onClickTermsAccept,
+    onClickWalletsLess,
+    onClickWalletsMore,
+    onConnectStart,
+    onConnectSuccess,
   };
 
   return {

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,20 @@
 # reef-knot
 
+## 7.0.0
+
+### Major Changes
+
+- Metrics config refactored, replaced with certain actions callbacks
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/connect-wallet-modal@7.0.0
+  - @reef-knot/core-react@6.0.0
+  - @reef-knot/types@4.0.0
+  - @reef-knot/web3-react@6.0.0
+  - @reef-knot/wallets-list@4.0.0
+
 ## 6.0.4
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "6.0.4",
+  "version": "7.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,13 +41,13 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "6.0.2",
-    "@reef-knot/core-react": "5.1.0",
-    "@reef-knot/web3-react": "5.0.0",
+    "@reef-knot/connect-wallet-modal": "7.0.0",
+    "@reef-knot/core-react": "6.0.0",
+    "@reef-knot/web3-react": "6.0.0",
     "@reef-knot/ui-react": "2.1.5",
-    "@reef-knot/wallets-list": "3.0.0",
+    "@reef-knot/wallets-list": "4.0.0",
     "@reef-knot/wallets-helpers": "2.1.1",
-    "@reef-knot/types": "3.0.0",
+    "@reef-knot/types": "4.0.0",
     "@reef-knot/ledger-connector": "4.2.0"
   },
   "peerDependencies": {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/types
 
+## 4.0.0
+
+### Major Changes
+
+- Metrics config refactored, replaced with certain actions callbacks
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/types",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "",
   "types": "dist/index.d.ts",
   "type": "module",

--- a/packages/types/src/reef-knot-wallets-modal.ts
+++ b/packages/types/src/reef-knot-wallets-modal.ts
@@ -2,35 +2,23 @@ import type { ComponentType } from 'react';
 import type { ModalProps } from '@reef-knot/ui-react';
 import type { ConnectWalletButtonProps } from './wallet-connect-button';
 
-export type MetricsProp<WalletIdsList extends string = string> = {
-  events?: {
-    connect?: {
-      handlers: Partial<Record<WalletIdsList, () => void>>;
-    };
-    click?: {
-      handlers: Partial<
-        Record<
-          WalletIdsList | 'termsAccept' | 'walletsMore' | 'walletsLess',
-          () => void
-        >
-      >;
-    };
-  };
-};
-
 export type ButtonComponentsByConnectorId = {
   [key: string]: ComponentType<ConnectWalletButtonProps>;
 };
 
 export type ReefKnotWalletsModalConfig<I extends string = string> = {
   buttonComponentsByConnectorId: ButtonComponentsByConnectorId;
-  metrics: MetricsProp<I>;
   walletsShown: I[];
   walletsPinned: I[];
   walletsDisplayInitialCount?: number;
   linkTerms?: string;
   linkPrivacyNotice?: string;
   linkDontHaveWallet?: string;
+  onConnectStart?: (walletId: I) => void;
+  onConnectSuccess?: (walletId: I) => void;
+  onClickTermsAccept?: (isAccepted: boolean) => void;
+  onClickWalletsMore?: () => void;
+  onClickWalletsLess?: () => void;
 };
 
 export type ReefKnotWalletsModalProps<I extends string = string> =

--- a/packages/types/src/reef-knot-wallets-modal.ts
+++ b/packages/types/src/reef-knot-wallets-modal.ts
@@ -14,9 +14,9 @@ export type ReefKnotWalletsModalConfig<I extends string = string> = {
   linkTerms?: string;
   linkPrivacyNotice?: string;
   linkDontHaveWallet?: string;
-  onConnectStart?: (walletId: I) => void;
-  onConnectSuccess?: (walletId: I) => void;
-  onClickTermsAccept?: (isAccepted: boolean) => void;
+  onConnectStart?: (args: { walletId: I }) => void;
+  onConnectSuccess?: (args: { walletId: I }) => void;
+  onClickTermsAccept?: (args: { isAccepted: boolean }) => void;
   onClickWalletsMore?: () => void;
   onClickWalletsLess?: () => void;
 };

--- a/packages/types/src/wallet-connect-button.ts
+++ b/packages/types/src/wallet-connect-button.ts
@@ -1,7 +1,6 @@
 import type { ButtonProps } from '@reef-knot/ui-react';
 import type { Connector, CreateConnectorFn } from 'wagmi';
 import type { WalletAdapterData } from './walletAdapter';
-import type { MetricsProp } from './reef-knot-wallets-modal';
 
 export type ConnectButtonBaseProps = ButtonProps & {
   icon?: WalletAdapterData['icon'];
@@ -19,6 +18,6 @@ export type ConnectWalletButtonProps = ConnectButtonBaseProps & {
   walletconnectExtras?: WalletAdapterData['walletconnectExtras'];
   connector: Connector | CreateConnectorFn;
   disabled: boolean;
-  metrics?: MetricsProp;
-  onConnect?: () => void;
+  onConnectStart?: () => void;
+  onConnectSuccess?: () => void;
 };

--- a/packages/wallets-list/CHANGELOG.md
+++ b/packages/wallets-list/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @reef-knot/wallets-list
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+  - @reef-knot/wallet-adapter-ambire@4.0.0
+  - @reef-knot/wallet-adapter-binance-wallet@3.0.0
+  - @reef-knot/wallet-adapter-bitkeep@4.0.0
+  - @reef-knot/wallet-adapter-brave@4.0.0
+  - @reef-knot/wallet-adapter-browser-extension@4.0.0
+  - @reef-knot/wallet-adapter-coin98@4.0.0
+  - @reef-knot/wallet-adapter-coinbase@4.0.0
+  - @reef-knot/wallet-adapter-coinbase-smart-wallet@3.0.0
+  - @reef-knot/wallet-adapter-dapp-browser-injected@4.0.0
+  - @reef-knot/wallet-adapter-exodus@4.0.0
+  - @reef-knot/wallet-adapter-imtoken@4.0.0
+  - @reef-knot/wallet-adapter-ledger-hid@5.0.0
+  - @reef-knot/wallet-adapter-ledger-live@5.0.0
+  - @reef-knot/wallet-adapter-metamask@4.0.0
+  - @reef-knot/wallet-adapter-okx@4.0.0
+  - @reef-knot/wallet-adapter-safe@4.0.0
+  - @reef-knot/wallet-adapter-trust@4.0.0
+  - @reef-knot/wallet-adapter-walletconnect@4.0.0
+  - @reef-knot/wallet-adapter-xdefi@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-list",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,32 +37,32 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/wallet-adapter-browser-extension": "3.0.0",
-    "@reef-knot/wallet-adapter-metamask": "3.0.0",
-    "@reef-knot/wallet-adapter-okx": "3.0.0",
-    "@reef-knot/wallet-adapter-exodus": "3.0.0",
-    "@reef-knot/wallet-adapter-walletconnect": "3.0.0",
-    "@reef-knot/wallet-adapter-ambire": "3.0.0",
-    "@reef-knot/wallet-adapter-binance-wallet": "2.0.0",
-    "@reef-knot/wallet-adapter-bitkeep": "3.0.0",
-    "@reef-knot/wallet-adapter-coin98": "3.0.0",
-    "@reef-knot/wallet-adapter-brave": "3.0.0",
-    "@reef-knot/wallet-adapter-imtoken": "3.0.0",
-    "@reef-knot/wallet-adapter-trust": "3.0.0",
-    "@reef-knot/wallet-adapter-xdefi": "3.0.0",
-    "@reef-knot/wallet-adapter-coinbase": "3.0.0",
-    "@reef-knot/wallet-adapter-coinbase-smart-wallet": "2.0.0",
-    "@reef-knot/wallet-adapter-ledger-hid": "4.0.0",
-    "@reef-knot/wallet-adapter-ledger-live": "4.0.0",
-    "@reef-knot/wallet-adapter-dapp-browser-injected": "3.0.0",
-    "@reef-knot/wallet-adapter-safe": "3.0.0"
+    "@reef-knot/wallet-adapter-browser-extension": "4.0.0",
+    "@reef-knot/wallet-adapter-metamask": "4.0.0",
+    "@reef-knot/wallet-adapter-okx": "4.0.0",
+    "@reef-knot/wallet-adapter-exodus": "4.0.0",
+    "@reef-knot/wallet-adapter-walletconnect": "4.0.0",
+    "@reef-knot/wallet-adapter-ambire": "4.0.0",
+    "@reef-knot/wallet-adapter-binance-wallet": "3.0.0",
+    "@reef-knot/wallet-adapter-bitkeep": "4.0.0",
+    "@reef-knot/wallet-adapter-coin98": "4.0.0",
+    "@reef-knot/wallet-adapter-brave": "4.0.0",
+    "@reef-knot/wallet-adapter-imtoken": "4.0.0",
+    "@reef-knot/wallet-adapter-trust": "4.0.0",
+    "@reef-knot/wallet-adapter-xdefi": "4.0.0",
+    "@reef-knot/wallet-adapter-coinbase": "4.0.0",
+    "@reef-knot/wallet-adapter-coinbase-smart-wallet": "3.0.0",
+    "@reef-knot/wallet-adapter-ledger-hid": "5.0.0",
+    "@reef-knot/wallet-adapter-ledger-live": "5.0.0",
+    "@reef-knot/wallet-adapter-dapp-browser-injected": "4.0.0",
+    "@reef-knot/wallet-adapter-safe": "4.0.0"
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "react": ">=18"
   }
 }

--- a/packages/wallets/ambire/CHANGELOG.md
+++ b/packages/wallets/ambire/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-ambire
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/ambire/package.json
+++ b/packages/wallets/ambire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ambire",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "wagmi": ">=2.12",
     "@reef-knot/wallets-helpers": "^2.0.0",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets/binance-wallet/CHANGELOG.md
+++ b/packages/wallets/binance-wallet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-binance-wallet
 
+## 3.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/wallets/binance-wallet/package.json
+++ b/packages/wallets/binance-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-binance-wallet",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "wagmi": ">=2.12"
   },

--- a/packages/wallets/bitkeep/CHANGELOG.md
+++ b/packages/wallets/bitkeep/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-bitkeep
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/bitkeep/package.json
+++ b/packages/wallets/bitkeep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-bitkeep",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/brave/CHANGELOG.md
+++ b/packages/wallets/brave/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-brave
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/brave/package.json
+++ b/packages/wallets/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-brave",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/browserExtension/CHANGELOG.md
+++ b/packages/wallets/browserExtension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-browser-extension
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/browserExtension/package.json
+++ b/packages/wallets/browserExtension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-browser-extension",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets/coin98/CHANGELOG.md
+++ b/packages/wallets/coin98/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-coin98
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/coin98/package.json
+++ b/packages/wallets/coin98/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coin98",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/coinbase-smart-wallet/CHANGELOG.md
+++ b/packages/wallets/coinbase-smart-wallet/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-coinbase-smart-wallet
 
+## 3.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 2.0.0
 
 ### Patch Changes

--- a/packages/wallets/coinbase-smart-wallet/package.json
+++ b/packages/wallets/coinbase-smart-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coinbase-smart-wallet",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets/coinbase/CHANGELOG.md
+++ b/packages/wallets/coinbase/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-coinbase
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/coinbase/package.json
+++ b/packages/wallets/coinbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coinbase",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/dappBrowserInjected/CHANGELOG.md
+++ b/packages/wallets/dappBrowserInjected/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-dapp-browser-injected
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/dappBrowserInjected/package.json
+++ b/packages/wallets/dappBrowserInjected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-dapp-browser-injected",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/exodus/CHANGELOG.md
+++ b/packages/wallets/exodus/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-exodus
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-exodus",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/imtoken/CHANGELOG.md
+++ b/packages/wallets/imtoken/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-imtoken
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/imtoken/package.json
+++ b/packages/wallets/imtoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-imtoken",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,13 +32,13 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets/ledger-hid/CHANGELOG.md
+++ b/packages/wallets/ledger-hid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-ledger-hid
 
+## 5.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/ledger-hid/package.json
+++ b/packages/wallets/ledger-hid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ledger-hid",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ledger-connector": "^4.1.4",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ledger-connector": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/ledger-live/CHANGELOG.md
+++ b/packages/wallets/ledger-live/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-ledger-live
 
+## 5.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/ledger-live/package.json
+++ b/packages/wallets/ledger-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ledger-live",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ledger-connector": "^4.1.4",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/ledger-connector": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/metamask/CHANGELOG.md
+++ b/packages/wallets/metamask/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-metamask
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/metamask/package.json
+++ b/packages/wallets/metamask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-metamask",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/okx/CHANGELOG.md
+++ b/packages/wallets/okx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-okx
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-okx",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/phantom/CHANGELOG.md
+++ b/packages/wallets/phantom/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-phantom
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-phantom",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/safe/CHANGELOG.md
+++ b/packages/wallets/safe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-safe
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/safe/package.json
+++ b/packages/wallets/safe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-safe",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "viem": ">=2.21",
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets/trust/CHANGELOG.md
+++ b/packages/wallets/trust/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-trust
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/trust/package.json
+++ b/packages/wallets/trust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-trust",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/walletconnect/CHANGELOG.md
+++ b/packages/wallets/walletconnect/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-walletconnect
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-walletconnect",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "wagmi": ">=2.12",
     "@reef-knot/wallets-helpers": "^2.0.0",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets/xdefi/CHANGELOG.md
+++ b/packages/wallets/xdefi/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/wallet-adapter-xdefi
 
+## 4.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/types@4.0.0
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/xdefi/package.json
+++ b/packages/wallets/xdefi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-xdefi",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,14 +32,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
     "wagmi": ">=2.12",
-    "@reef-knot/types": "^3.0.0",
+    "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @reef-knot/web3-react
 
+## 6.0.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/core-react@6.0.0
+
 ## 5.0.0
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -46,7 +46,7 @@
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.18.6",
     "@ethersproject/providers": "^5.7.2",
-    "@reef-knot/core-react": "^5.0.0",
+    "@reef-knot/core-react": "^6.0.0",
     "@reef-knot/ledger-connector": "^4.1.4",
     "@reef-knot/wallets-helpers": "^2.1.1",
     "@testing-library/react": "^12.1.5",
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "@ethersproject/providers": "5",
-    "@reef-knot/core-react": "^5.0.0",
+    "@reef-knot/core-react": "^6.0.0",
     "@reef-knot/ledger-connector": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "react": ">=18",


### PR DESCRIPTION
### Description
The idea is to replace specific `metrics` argument during `ReefKnotWalletsModal` setup with more generic appropriate action callback props, so the connector buttons should not know anything about or define any metrics structure of the destination project.

### Code review notes
The `MetricsProp` structure was removed. It was overcomplicated with such paths as
- `metrics?.events?.click?.handlers.onClickTermsAccept`
- `metrics?.events?.click?.handlers.walletsMore`
- `metrics?.events?.click?.handlers.walletsLess`
- `metrics?.events?.click?.handlers[walletId]`

It was replaced with plain callbacks:
- `onClickTermsAccept({ isAccepted })`
- `onClickWalletsMore()`
- `onClickWalletsLess()`
- `onConnectStart({ walletId })`
- `onConnectSuccess({ walletId })`

### Testing notes
Affected metric events should work the same way as before:
- Terms acceptance events
- Wallets click and connection events
- Show/hide more wallets event

Also there was a logic error found in the way how successfully connection metric event was accounted for Ledger HID. Please, give some attention to Ledger HID connection, to ensure it works fine.