### PR TITLE
Tests for wrap/unwrap transactions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: test
     env:
       TEST_BRANCH: ${{ github.event.inputs.branch }}

--- a/playwright-tests/pages/components/index.ts
+++ b/playwright-tests/pages/components/index.ts
@@ -4,3 +4,4 @@ export * from './wallet-list-modal';
 export * from './wallet-modal';
 export * from './toast';
 export * from './stake-block';
+export * from './wrap-unwrap-block';

--- a/playwright-tests/pages/components/stats.ts
+++ b/playwright-tests/pages/components/stats.ts
@@ -1,4 +1,6 @@
 import { Locator, Page } from '@playwright/test';
+import { TIMEOUT } from '@test-data';
+import { waitForCallback } from '@services';
 
 export class StatsBlock {
   page: Page;
@@ -21,5 +23,44 @@ export class StatsBlock {
     this.stethBalance = this.mainComponent.getByTestId('stETH');
     this.wstethBalance = this.mainComponent.getByTestId('wstETH');
     this.amountInput = this.mainComponent.getByTestId('amountInput');
+  }
+
+  async getEthBalance() {
+    return await waitForCallback(
+      async (locator: Locator) => {
+        return await locator.evaluate((element) => {
+          const balance = parseFloat(element.textContent);
+          return balance || balance == 0 ? String(balance) : null;
+        });
+      },
+      this.ethBalance,
+      TIMEOUT.RPC_WAIT,
+    );
+  }
+
+  async getStEthBalance() {
+    return await waitForCallback(
+      async (locator: Locator) => {
+        return await locator.evaluate((element) => {
+          const balance = parseFloat(element.textContent);
+          return balance || balance == 0 ? String(balance) : null;
+        });
+      },
+      this.stethBalance,
+      TIMEOUT.RPC_WAIT,
+    );
+  }
+
+  async getWstEthBalance() {
+    return await waitForCallback(
+      async (locator: Locator) => {
+        return await locator.evaluate((element) => {
+          const balance = parseFloat(element.textContent);
+          return balance || balance == 0 ? String(balance) : null;
+        });
+      },
+      this.wstethBalance,
+      TIMEOUT.RPC_WAIT,
+    );
   }
 }

--- a/playwright-tests/pages/components/wrap-unwrap-block.ts
+++ b/playwright-tests/pages/components/wrap-unwrap-block.ts
@@ -1,0 +1,49 @@
+import { Locator, Page, test } from '@playwright/test';
+
+export class WrapUnwrapBlock {
+  page: Page;
+  mainComponent: Locator;
+  wrapBtn: Locator;
+  unwrapBtn: Locator;
+  txTypeSelector: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.mainComponent = this.page
+      .getByTestId('WrapBlock')
+      .or(this.page.getByTestId('UnwrapBlock'));
+    this.wrapBtn = this.mainComponent.locator('button :has-text("Wrap")');
+    this.unwrapBtn = this.mainComponent.locator('button :has-text("Unwrap")');
+    this.txTypeSelector = this.mainComponent.locator('label');
+  }
+
+  async selectWrapEthTxType() {
+    await test.step('Select the Wrap ETH tx type', async () => {
+      await this.txTypeSelector.click();
+      await this.page
+        .locator('id=lido-ui-modal-root')
+        .locator('button', { hasText: 'Wrap ETH' })
+        .click();
+    });
+  }
+
+  async selectWrapStEthTxType() {
+    await test.step('Select the Wrap stETH tx type', async () => {
+      await this.txTypeSelector.click();
+      await this.page
+        .locator('id=lido-ui-modal-root')
+        .locator('button', { hasText: 'Wrap stETH' })
+        .click();
+    });
+  }
+
+  async selectUnwrapTxType() {
+    await test.step('Select the Unwrap tx type', async () => {
+      await this.txTypeSelector.click();
+      await this.page
+        .locator('id=lido-ui-modal-root')
+        .locator('button', { hasText: 'Unwrap' })
+        .click();
+    });
+  }
+}

--- a/playwright-tests/pages/reefKnot.page.ts
+++ b/playwright-tests/pages/reefKnot.page.ts
@@ -100,7 +100,7 @@ export class ReefKnotPage {
       async (locator: Locator) => {
         return await locator.evaluate((element) => {
           const balance = parseFloat(element.textContent);
-          return String(balance) ? String(balance) : null;
+          return balance ? String(balance) : null;
         });
       },
       locator,

--- a/playwright-tests/pages/reefKnot.page.ts
+++ b/playwright-tests/pages/reefKnot.page.ts
@@ -81,7 +81,7 @@ export class ReefKnotPage {
       async (locator: Locator) => {
         return await locator.evaluate((element) => {
           const balance = parseFloat(element.textContent);
-          return balance ? String(balance) : null;
+          return String(balance) ? String(balance) : null;
         });
       },
       locator,

--- a/playwright-tests/pages/reefKnot.page.ts
+++ b/playwright-tests/pages/reefKnot.page.ts
@@ -7,9 +7,8 @@ import {
   Toast,
   WrapUnwrapBlock,
 } from './components';
-import { Locator, Page, test } from '@playwright/test';
+import { Page, test } from '@playwright/test';
 import { TIMEOUT } from '@test-data';
-import { waitForCallback } from '@services';
 
 export class ReefKnotPage {
   readonly page: Page;
@@ -93,18 +92,5 @@ export class ReefKnotPage {
       this.wrapUnwrapBlock.unwrapBtn.click(),
     ]);
     return txPage;
-  }
-
-  async waitForBalance(locator: Locator, timeout = TIMEOUT.RPC_WAIT) {
-    return await waitForCallback(
-      async (locator: Locator) => {
-        return await locator.evaluate((element) => {
-          const balance = parseFloat(element.textContent);
-          return balance ? String(balance) : null;
-        });
-      },
-      locator,
-      timeout,
-    );
   }
 }

--- a/playwright-tests/pages/reefKnot.page.ts
+++ b/playwright-tests/pages/reefKnot.page.ts
@@ -5,6 +5,7 @@ import {
   WalletModal,
   StakeBlock,
   Toast,
+  WrapUnwrapBlock,
 } from './components';
 import { Locator, Page, test } from '@playwright/test';
 import { TIMEOUT } from '@test-data';
@@ -16,6 +17,7 @@ export class ReefKnotPage {
   walletModal: WalletModal;
   statsBlock: StatsBlock;
   stakeBlock: StakeBlock;
+  wrapUnwrapBlock: WrapUnwrapBlock;
   walletListModal: WalletListModal;
   toast: Toast;
 
@@ -25,6 +27,7 @@ export class ReefKnotPage {
     this.walletModal = new WalletModal(this.page);
     this.statsBlock = new StatsBlock(this.page);
     this.stakeBlock = new StakeBlock(this.page);
+    this.wrapUnwrapBlock = new WrapUnwrapBlock(this.page);
     this.walletListModal = new WalletListModal(this.page);
     this.toast = new Toast(this.page);
   }
@@ -72,6 +75,22 @@ export class ReefKnotPage {
     const [txPage] = await Promise.all([
       this.waitForPage(TIMEOUT.RPC_WAIT),
       this.stakeBlock.stakeBtn.click(),
+    ]);
+    return txPage;
+  }
+
+  async clickWrapButton() {
+    const [txPage] = await Promise.all([
+      this.waitForPage(TIMEOUT.RPC_WAIT),
+      this.wrapUnwrapBlock.wrapBtn.click(),
+    ]);
+    return txPage;
+  }
+
+  async clickUnwrapButton() {
+    const [txPage] = await Promise.all([
+      this.waitForPage(TIMEOUT.RPC_WAIT),
+      this.wrapUnwrapBlock.unwrapBtn.click(),
     ]);
     return txPage;
   }

--- a/playwright-tests/playwright.config.ts
+++ b/playwright-tests/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
   },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: 1,
+  retries: process.env.CI ? 1 : 0,
   workers: 1,
   reporter: getReportConfig(),
   use: {

--- a/playwright-tests/services/helpers.ts
+++ b/playwright-tests/services/helpers.ts
@@ -3,11 +3,15 @@
  *
  * Example:
  * ```ts
- * 0.12345 => toCut('0.12345', 3) => '0.123'
- * 0.101 => toCut('0.101', 2, true) => '0.1'
+ * 0.12345 => toСutDecimalsDigit('0.12345', 3) => '0.123'
+ * 0.101 => toСutDecimalsDigit('0.101', 2, true) => '0.1'
  * ```
  */
-export function toCut(amount: any, decimalPlaces: number, removeZero = false) {
+export function toCutDecimalsDigit(
+  amount: any,
+  decimalPlaces: number,
+  removeZero = false,
+) {
   const parts = String(amount).split(/\./);
   let respLength: number;
   if (parts.length === 2) {

--- a/playwright-tests/services/helpers.ts
+++ b/playwright-tests/services/helpers.ts
@@ -4,15 +4,17 @@
  * Example:
  * ```ts
  * 0.12345 => toCut('0.12345', 3) => '0.123'
+ * 0.101 => toCut('0.101', 2, true) => '0.1'
  * ```
  */
-export function toCut(amount: any, decimalPlaces: number) {
-  const result = String(amount).split(/\./);
+export function toCut(amount: any, decimalPlaces: number, removeZero = false) {
+  const parts = String(amount).split(/\./);
   let respLength: number;
-  if (result.length === 2) {
-    respLength = result[0].length + 1 + decimalPlaces;
+  if (parts.length === 2) {
+    respLength = parts[0].length + 1 + decimalPlaces;
   }
-  return String(amount).slice(0, respLength);
+  const response = String(amount).slice(0, respLength);
+  return removeZero ? String(parseFloat(response)) : response;
 }
 
 /**

--- a/playwright-tests/services/helpers.ts
+++ b/playwright-tests/services/helpers.ts
@@ -6,13 +6,13 @@
  * 0.12345 => toCut('0.12345', 3) => '0.123'
  * ```
  */
-export function toCut(floatAmount: string, decimalPlaces: number) {
-  const result = floatAmount.split(/\./);
+export function toCut(amount: any, decimalPlaces: number) {
+  const result = String(amount).split(/\./);
   let respLength: number;
   if (result.length === 2) {
     respLength = result[0].length + 1 + decimalPlaces;
   }
-  return floatAmount.slice(0, respLength);
+  return String(amount).slice(0, respLength);
 }
 
 /**

--- a/playwright-tests/services/sdk.service.ts
+++ b/playwright-tests/services/sdk.service.ts
@@ -26,6 +26,14 @@ export class SdkService extends LidoSDK {
     });
   }
 
+  /**
+   Get token balance from SDK without 0 in the end of number
+   Example:
+   ```ts
+   // ETH balance = 1.102
+   getBalanceByToken(stdToken.ETH, 2) => '1.1'
+   ```
+   */
   async getBalanceByToken(token: sdkToken, decimalPlaces: number) {
     let balance: string;
     switch (token) {
@@ -39,7 +47,7 @@ export class SdkService extends LidoSDK {
         balance = formatEther(await this.wsteth.balance());
         break;
     }
-    return toCut(balance, decimalPlaces);
+    return toCut(balance, decimalPlaces, true);
   }
 
   async exchangeEthToWstEth(amount: any) {

--- a/playwright-tests/services/sdk.service.ts
+++ b/playwright-tests/services/sdk.service.ts
@@ -41,4 +41,28 @@ export class SdkService extends LidoSDK {
     }
     return toCut(balance, decimalPlaces);
   }
+
+  async exchangeEthToWstEth(amount: any) {
+    const wstethRate = formatEther(
+      await this.wrap.convertStethToWsteth(1000000000000000000n),
+    );
+    return parseFloat(wstethRate) * parseFloat(amount);
+  }
+
+  async exchangeWstEthToEth(amount: any) {
+    const wstethRate = formatEther(
+      await this.wrap.convertWstethToSteth(1000000000000000000n),
+    );
+    return parseFloat(wstethRate) * parseFloat(amount);
+  }
+
+  async getStEthAllowance() {
+    return parseFloat(
+      formatEther(
+        await this.steth.allowance({
+          to: `0x${REEF_KNOT_CONFIG.STAND_CONFIG.contracts.wrap.slice(2)}`,
+        }),
+      ),
+    );
+  }
 }

--- a/playwright-tests/services/sdk.service.ts
+++ b/playwright-tests/services/sdk.service.ts
@@ -1,8 +1,8 @@
 import { LidoSDK, VIEM_CHAINS } from '@lidofinance/lido-ethereum-sdk';
 import { HDAccount } from 'viem/accounts';
-import { createWalletClient, formatEther, http } from 'viem';
+import { createWalletClient, formatEther, http, type Address } from 'viem';
 import { REEF_KNOT_CONFIG } from '@config';
-import { toCut } from './helpers';
+import { toCutDecimalsDigit } from './helpers';
 
 global.fetch = fetch;
 
@@ -47,17 +47,17 @@ export class SdkService extends LidoSDK {
         balance = formatEther(await this.wsteth.balance());
         break;
     }
-    return toCut(balance, decimalPlaces, true);
+    return toCutDecimalsDigit(balance, decimalPlaces, true);
   }
 
-  async exchangeEthToWstEth(amount: any) {
+  async exchangeStEthToWstEth(amount: any) {
     const wstethRate = formatEther(
       await this.wrap.convertStethToWsteth(1000000000000000000n),
     );
     return parseFloat(wstethRate) * parseFloat(amount);
   }
 
-  async exchangeWstEthToEth(amount: any) {
+  async exchangeWstEthToStEth(amount: any) {
     const wstethRate = formatEther(
       await this.wrap.convertWstethToSteth(1000000000000000000n),
     );
@@ -68,7 +68,7 @@ export class SdkService extends LidoSDK {
     return parseFloat(
       formatEther(
         await this.steth.allowance({
-          to: `0x${REEF_KNOT_CONFIG.STAND_CONFIG.contracts.wrap.slice(2)}`,
+          to: REEF_KNOT_CONFIG.STAND_CONFIG.contracts.wrap as Address,
         }),
       ),
     );

--- a/playwright-tests/test-data/matomo.data.ts
+++ b/playwright-tests/test-data/matomo.data.ts
@@ -52,8 +52,8 @@ export const CONFIG_MATOMO_CLICK_TO_WALLET_EVENTS = [
     walletName: 'imToken',
   },
   {
-    eventMessage: 'xdefi clicked',
-    walletName: 'XDEFI',
+    eventMessage: 'ctrl clicked',
+    walletName: 'Ctrl',
   },
   {
     eventMessage: 'binanceWallet clicked',

--- a/playwright-tests/tests/transactions/stake-tx.spec.ts
+++ b/playwright-tests/tests/transactions/stake-tx.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { Tags, TIMEOUT } from '@test-data';
 import { BrowserService, initBrowserWithWallet } from '@browser';
-import { ReefKnotService, toCut } from '@services';
+import { ReefKnotService, toCutDecimalsDigit } from '@services';
 import { ReefKnotPage } from '@pages';
 import { qase } from 'playwright-qase-reporter';
 import { REEF_KNOT_CONFIG } from '@config';
@@ -39,12 +39,10 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
 
         const newStEthBalance =
           await test.step('Calculate the stETH amount result', async () => {
-            const stEthBalance = parseFloat(
-              await reefKnotPage.waitForBalance(
-                reefKnotPage.statsBlock.stethBalance,
-              ),
-            );
-            return toCut(stEthBalance + parseFloat(stakeAmount), 4);
+            const stethResult =
+              parseFloat(await reefKnotPage.statsBlock.getStEthBalance()) +
+              parseFloat(stakeAmount);
+            return toCutDecimalsDigit(stethResult, 4);
           });
 
         const txPage =

--- a/playwright-tests/tests/transactions/stake-tx.spec.ts
+++ b/playwright-tests/tests/transactions/stake-tx.spec.ts
@@ -31,7 +31,7 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
         await browserService.teardown();
       });
 
-      test(`Stake ${stakeAmount} ETH`, async () => {
+      test(qase(444, `Stake ${stakeAmount} ETH`), async () => {
         await qase.groupParameters({
           wallet: wallet.name,
           txAmount: stakeAmount,
@@ -44,7 +44,7 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
                 reefKnotPage.statsBlock.stethBalance,
               ),
             );
-            return toCut(String(stEthBalance + parseFloat(stakeAmount)), 4);
+            return toCut(stEthBalance + parseFloat(stakeAmount), 4);
           });
 
         const txPage =

--- a/playwright-tests/tests/transactions/unwrap-tx.spec.ts
+++ b/playwright-tests/tests/transactions/unwrap-tx.spec.ts
@@ -1,0 +1,92 @@
+import { REEF_KNOT_CONFIG } from '@config';
+import { expect, test } from '@playwright/test';
+import { Tags, TIMEOUT } from '@test-data';
+import { BrowserService, initBrowserWithWallet } from '@browser';
+import { ReefKnotService, toCut } from '@services';
+import { ReefKnotPage } from '@pages';
+import { qase } from 'playwright-qase-reporter';
+
+REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
+  test.describe(
+    `ReefKnot. Unwrap transaction (${wallet.name})`,
+    { tag: [Tags.connectedWallet, `@${wallet.name}`] },
+    async () => {
+      const unwrapAmount = '0.0003';
+      let browserService: BrowserService;
+      let reefKnotService: ReefKnotService;
+      let reefKnotPage: ReefKnotPage;
+
+      test.beforeAll(async () => {
+        ({ browserService, reefKnotService } = await initBrowserWithWallet(
+          wallet.name,
+        ));
+        reefKnotPage = reefKnotService.reefKnotPage;
+        await reefKnotPage.goto();
+        await reefKnotPage.allowUseCookies();
+        await reefKnotService.connectWallet();
+      });
+
+      test.afterAll(async () => {
+        await reefKnotService.disconnectWalletForce();
+        await browserService.teardown();
+      });
+
+      test(qase(447, `Unwrap ${unwrapAmount} wstETH`), async () => {
+        await qase.groupParameters({
+          wallet: wallet.name,
+          txAmount: unwrapAmount,
+        });
+
+        await reefKnotPage.wrapUnwrapBlock.selectUnwrapTxType();
+
+        const newStEthBalance =
+          await test.step('Calculate the stETH amount result', async () => {
+            const stEthBalance = parseFloat(
+              await reefKnotPage.waitForBalance(
+                reefKnotPage.statsBlock.stethBalance,
+              ),
+            );
+            return toCut(
+              stEthBalance +
+                (await reefKnotService.sdkService.exchangeWstEthToEth(
+                  unwrapAmount,
+                )),
+              4,
+            );
+          });
+
+        const txPage =
+          await test.step('Fill the amount input and click to Submit button', async () => {
+            await reefKnotPage.statsBlock.amountInput.fill(unwrapAmount);
+            return await reefKnotPage.clickUnwrapButton();
+          });
+
+        await reefKnotService.walletPage.confirmTx(txPage, true);
+
+        await test.step('Waiting for transaction success', async () => {
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.unwrapBtn,
+            'The Unwrap button should be disabled',
+          ).toBeDisabled();
+
+          await reefKnotPage.toast.successToast.waitFor({
+            state: 'visible',
+            timeout: TIMEOUT.RPC_WAIT,
+          });
+
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.unwrapBtn,
+            'The Unwrap button should be enabled after success tx',
+          ).toBeEnabled();
+        });
+
+        await test.step('Check the new stETH balance', async () => {
+          await expect(
+            reefKnotPage.statsBlock.stethBalance,
+            'The displayed stETH balance should be updated after transaction success',
+          ).toContainText(newStEthBalance, { timeout: TIMEOUT.HIGH });
+        });
+      });
+    },
+  );
+});

--- a/playwright-tests/tests/transactions/unwrap-tx.spec.ts
+++ b/playwright-tests/tests/transactions/unwrap-tx.spec.ts
@@ -2,7 +2,7 @@ import { REEF_KNOT_CONFIG } from '@config';
 import { expect, test } from '@playwright/test';
 import { Tags, TIMEOUT } from '@test-data';
 import { BrowserService, initBrowserWithWallet } from '@browser';
-import { ReefKnotService, toCut } from '@services';
+import { ReefKnotService, toCutDecimalsDigit } from '@services';
 import { ReefKnotPage } from '@pages';
 import { qase } from 'playwright-qase-reporter';
 
@@ -41,18 +41,12 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
 
         const newStEthBalance =
           await test.step('Calculate the stETH amount result', async () => {
-            const stEthBalance = parseFloat(
-              await reefKnotPage.waitForBalance(
-                reefKnotPage.statsBlock.stethBalance,
-              ),
-            );
-            return toCut(
-              stEthBalance +
-                (await reefKnotService.sdkService.exchangeWstEthToEth(
-                  unwrapAmount,
-                )),
-              4,
-            );
+            const stEthResult =
+              parseFloat(await reefKnotPage.statsBlock.getStEthBalance()) +
+              (await reefKnotService.sdkService.exchangeWstEthToStEth(
+                unwrapAmount,
+              ));
+            return toCutDecimalsDigit(stEthResult, 4);
           });
 
         const txPage =

--- a/playwright-tests/tests/transactions/wrap-tx.spec.ts
+++ b/playwright-tests/tests/transactions/wrap-tx.spec.ts
@@ -1,0 +1,188 @@
+import { REEF_KNOT_CONFIG } from '@config';
+import { expect, test } from '@playwright/test';
+import { Tags, TIMEOUT } from '@test-data';
+import { BrowserService, initBrowserWithWallet } from '@browser';
+import { ReefKnotService, toCut } from '@services';
+import { ReefKnotPage } from '@pages';
+import { qase } from 'playwright-qase-reporter';
+
+REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
+  test.describe(
+    `ReefKnot. Wrap transaction (${wallet.name})`,
+    { tag: [Tags.connectedWallet, `@${wallet.name}`] },
+    async () => {
+      const wrapAmount = '0.0003';
+      let browserService: BrowserService;
+      let reefKnotService: ReefKnotService;
+      let reefKnotPage: ReefKnotPage;
+
+      test.beforeAll(async () => {
+        ({ browserService, reefKnotService } = await initBrowserWithWallet(
+          wallet.name,
+        ));
+        reefKnotPage = reefKnotService.reefKnotPage;
+        await reefKnotPage.goto();
+        await reefKnotPage.allowUseCookies();
+        await reefKnotService.connectWallet();
+      });
+
+      test.afterAll(async () => {
+        await reefKnotService.disconnectWalletForce();
+        await browserService.teardown();
+      });
+
+      test(qase(445, `Wrap ${wrapAmount} ETH`), async () => {
+        await qase.groupParameters({
+          wallet: wallet.name,
+          txAmount: wrapAmount,
+        });
+
+        await reefKnotPage.wrapUnwrapBlock.selectWrapEthTxType();
+
+        const newWstEthBalance =
+          await test.step('Calculate the wstETH amount result', async () => {
+            const wstEthBalance = parseFloat(
+              await reefKnotPage.waitForBalance(
+                reefKnotPage.statsBlock.wstethBalance,
+              ),
+            );
+            return toCut(
+              wstEthBalance +
+                (await reefKnotService.sdkService.exchangeEthToWstEth(
+                  wrapAmount,
+                )),
+              4,
+            );
+          });
+
+        const txPage =
+          await test.step('Fill the amount input and click to Submit button', async () => {
+            await reefKnotPage.statsBlock.amountInput.fill(wrapAmount);
+            return await reefKnotPage.clickWrapButton();
+          });
+
+        await reefKnotService.walletPage.confirmTx(txPage, true);
+
+        await test.step('Waiting for transaction success', async () => {
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.wrapBtn,
+            'The Wrap button should be disabled',
+          ).toBeDisabled();
+
+          await reefKnotPage.toast.successToast.waitFor({
+            state: 'visible',
+            timeout: TIMEOUT.RPC_WAIT,
+          });
+
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.wrapBtn,
+            'The Wrap button should be enabled after success tx',
+          ).toBeEnabled();
+        });
+
+        await test.step('Check the new wstETH balance', async () => {
+          await expect(
+            reefKnotPage.statsBlock.wstethBalance,
+            'The displayed wstETH balance should be updated after transaction success',
+          ).toContainText(newWstEthBalance, { timeout: TIMEOUT.HIGH });
+        });
+      });
+
+      test(qase(446, `Wrap ${wrapAmount} stETH`), async () => {
+        await qase.groupParameters({
+          wallet: wallet.name,
+          txAmount: wrapAmount,
+        });
+
+        await test.step('Set up correct allowance before test', async () => {
+          if (
+            (await reefKnotService.sdkService.getStEthAllowance()) >=
+            parseFloat(wrapAmount)
+          ) {
+            await reefKnotService.sdkService.wrap.approveStethForWrap({
+              value: 0n,
+            });
+          }
+        });
+
+        await reefKnotPage.wrapUnwrapBlock.selectWrapStEthTxType();
+
+        const newWstEthBalance =
+          await test.step('Calculate the wstETH amount result', async () => {
+            const wstEthBalance = parseFloat(
+              await reefKnotPage.waitForBalance(
+                reefKnotPage.statsBlock.wstethBalance,
+              ),
+            );
+            return toCut(
+              wstEthBalance +
+                (await reefKnotService.sdkService.exchangeEthToWstEth(
+                  wrapAmount,
+                )),
+              4,
+            );
+          });
+
+        let txPage =
+          await test.step('Fill the amount input and click to Submit button', async () => {
+            await reefKnotPage.statsBlock.amountInput.fill(wrapAmount);
+            return await reefKnotPage.clickWrapButton();
+          });
+
+        await test.step('Confirm tx of stETH approval', async () => {
+          await reefKnotService.walletPage.approveTokenTx(txPage);
+        });
+
+        await test.step('Waiting for the approval success', async () => {
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.wrapBtn,
+            'The Wrap button should be disabled',
+          ).toBeDisabled();
+
+          [txPage] = await Promise.all([
+            reefKnotPage.waitForPage(TIMEOUT.RPC_WAIT),
+            reefKnotPage.toast.successToast.waitFor({
+              state: 'visible',
+              timeout: TIMEOUT.RPC_WAIT,
+            }),
+          ]);
+
+          await test.step('Wait for the toast to be disappeared', async () => {
+            await reefKnotPage.toast.successToast.waitFor({
+              state: 'hidden',
+              timeout: TIMEOUT.HIGH,
+            });
+          });
+        });
+
+        await test.step('Confirm tx of stETH wrapping', async () => {
+          await reefKnotService.walletPage.confirmTx(txPage);
+        });
+
+        await test.step('Waiting for the wrapping success', async () => {
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.wrapBtn,
+            'The Wrap button should be disabled',
+          ).toBeDisabled();
+
+          await reefKnotPage.toast.successToast.waitFor({
+            state: 'visible',
+            timeout: TIMEOUT.RPC_WAIT,
+          });
+
+          await expect(
+            reefKnotPage.wrapUnwrapBlock.wrapBtn,
+            'The Wrap button should be enabled after success tx',
+          ).toBeEnabled();
+        });
+
+        await test.step('Check the new wstETH balance', async () => {
+          await expect(
+            reefKnotPage.statsBlock.wstethBalance,
+            'The displayed wstETH balance should be updated after transaction success',
+          ).toContainText(newWstEthBalance, { timeout: TIMEOUT.HIGH });
+        });
+      });
+    },
+  );
+});

--- a/playwright-tests/tests/transactions/wrap-tx.spec.ts
+++ b/playwright-tests/tests/transactions/wrap-tx.spec.ts
@@ -2,7 +2,7 @@ import { REEF_KNOT_CONFIG } from '@config';
 import { expect, test } from '@playwright/test';
 import { Tags, TIMEOUT } from '@test-data';
 import { BrowserService, initBrowserWithWallet } from '@browser';
-import { ReefKnotService, toCut } from '@services';
+import { ReefKnotService, toCutDecimalsDigit } from '@services';
 import { ReefKnotPage } from '@pages';
 import { qase } from 'playwright-qase-reporter';
 
@@ -41,18 +41,12 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
 
         const newWstEthBalance =
           await test.step('Calculate the wstETH amount result', async () => {
-            const wstEthBalance = parseFloat(
-              await reefKnotPage.waitForBalance(
-                reefKnotPage.statsBlock.wstethBalance,
-              ),
-            );
-            return toCut(
-              wstEthBalance +
-                (await reefKnotService.sdkService.exchangeEthToWstEth(
-                  wrapAmount,
-                )),
-              4,
-            );
+            const wstethResult =
+              parseFloat(await reefKnotPage.statsBlock.getWstEthBalance()) +
+              (await reefKnotService.sdkService.exchangeStEthToWstEth(
+                wrapAmount,
+              ));
+            return toCutDecimalsDigit(wstethResult, 4);
           });
 
         const txPage =
@@ -109,18 +103,12 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
 
         const newWstEthBalance =
           await test.step('Calculate the wstETH amount result', async () => {
-            const wstEthBalance = parseFloat(
-              await reefKnotPage.waitForBalance(
-                reefKnotPage.statsBlock.wstethBalance,
-              ),
-            );
-            return toCut(
-              wstEthBalance +
-                (await reefKnotService.sdkService.exchangeEthToWstEth(
-                  wrapAmount,
-                )),
-              4,
-            );
+            const wstethResult =
+              parseFloat(await reefKnotPage.statsBlock.getWstEthBalance()) +
+              (await reefKnotService.sdkService.exchangeStEthToWstEth(
+                wrapAmount,
+              ));
+            return toCutDecimalsDigit(wstethResult, 4);
           });
 
         let txPage =

--- a/playwright-tests/tests/wallet-stats.spec.ts
+++ b/playwright-tests/tests/wallet-stats.spec.ts
@@ -53,7 +53,7 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
       test(qase(437, 'Check ETH balance'), async () => {
         await qase.parameters({ wallet: wallet.name });
         expect(
-          await reefKnotPage.waitForBalance(reefKnotPage.statsBlock.ethBalance),
+          await reefKnotPage.statsBlock.getEthBalance(),
           'The address ETH balance should match the value displayed in the ReefKnot stats block',
         ).toContain(
           await reefKnotService.sdkService.getBalanceByToken(sdkToken.ETH, 5),
@@ -63,9 +63,7 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
       test(qase(438, 'Check stETH balance'), async () => {
         await qase.parameters({ wallet: wallet.name });
         expect(
-          await reefKnotPage.waitForBalance(
-            reefKnotPage.statsBlock.stethBalance,
-          ),
+          await reefKnotPage.statsBlock.getStEthBalance(),
           'The address stETH balance should match the value displayed in the ReefKnot stats block',
         ).toContain(
           await reefKnotService.sdkService.getBalanceByToken(sdkToken.stETH, 5),
@@ -75,9 +73,7 @@ REEF_KNOT_CONFIG.WALLETS.forEach((wallet) => {
       test(qase(439, 'Check wstETH balance'), async () => {
         await qase.parameters({ wallet: wallet.name });
         expect(
-          await reefKnotPage.waitForBalance(
-            reefKnotPage.statsBlock.wstethBalance,
-          ),
+          await reefKnotPage.statsBlock.getWstEthBalance(),
           'The address wstETH balance should match the value displayed in the ReefKnot stats block',
         ).toContain(
           await reefKnotService.sdkService.getBalanceByToken(


### PR DESCRIPTION
## Notes:
- added tests for
  - Wrap ETH
  - Wrap stETH
  - Unwrap wstETH
- changed XDEFI wallet to Ctrl wallet
- some fixes

## Testrun result
<img width="940" alt="image" src="https://github.com/user-attachments/assets/35b1b2a9-520e-4e77-be37-5c50aae1e3c2" />

- [Test ReefKnot action](https://github.com/lidofinance/reef-knot/actions/runs/13033160318)
