### PR TITLE
Update viem and wagmi

### DIFF
--- a/apps/demo-react/package.json
+++ b/apps/demo-react/package.json
@@ -32,8 +32,8 @@
     "swr": "^2.2.5",
     "tiny-invariant": "^1.3.1",
     "url-loader": "^4.1.1",
-    "viem": "^2.21.37",
-    "wagmi": "^2.12.25"
+    "viem": "^2.23.1",
+    "wagmi": "^2.14.11"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @reef-knot/connect-wallet-modal
 
+## 7.2.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
+### Patch Changes
+
+- @reef-knot/wallets-list@4.1.2
+
 ## 7.1.0
 
 ### Minor Changes

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/connect-wallet-modal",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,17 +41,17 @@
     "@ledgerhq/hw-app-eth": "^6.37.1",
     "@ledgerhq/hw-transport-webhid": "^6.29.0",
     "@lidofinance/lido-ui": "^3.18.0",
-    "@reef-knot/wallets-list": "^4.1.0",
+    "@reef-knot/wallets-list": "^4.1.2",
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.17"
   },
   "devDependencies": {
-    "@reef-knot/core-react": "^6.0.0",
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/ui-react": "^2.1.5",
-    "@reef-knot/wallets-helpers": "^2.1.1",
-    "@reef-knot/web3-react": "^6.0.0",
-    "@reef-knot/ledger-connector": "^4.1.4",
+    "@reef-knot/core-react": "^6.1.0",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/ui-react": "^2.2.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
+    "@reef-knot/web3-react": "^6.1.0",
+    "@reef-knot/ledger-connector": "^4.3.0",
     "eslint-config-custom": "*",
     "react": "18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/connect-wallet-modal/package.json
+++ b/packages/connect-wallet-modal/package.json
@@ -55,8 +55,8 @@
     "eslint-config-custom": "*",
     "react": "18.2.0",
     "react-dom": "^18.2.0",
-    "viem": ">=2.21",
-    "wagmi": ">=2.12"
+    "viem": ">=2.23",
+    "wagmi": ">=2.14"
   },
   "peerDependencies": {
     "@reef-knot/core-react": "^6.0.0",
@@ -67,8 +67,8 @@
     "@reef-knot/ledger-connector": "^4.0.0",
     "react": ">=18",
     "@lidofinance/lido-ui": "^3.18.0",
-    "viem": ">=2.21",
-    "wagmi": ">=2.12",
+    "viem": ">=2.23",
+    "wagmi": ">=2.14",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/connectors/ledger-connector/CHANGELOG.md
+++ b/packages/connectors/ledger-connector/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/ledger-connector
 
+## 4.3.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.2.0
 
 ### Minor Changes

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ledger-connector",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -33,8 +33,8 @@
   },
   "devDependencies": {
     "@types/w3c-web-hid": "^1.0.2",
-    "viem": ">=2.21",
-    "wagmi": ">=2.12",
+    "viem": ">=2.23",
+    "wagmi": ">=2.14",
     "eslint-config-custom": "*"
   },
   "dependencies": {
@@ -56,8 +56,8 @@
     "tiny-invariant": "^1.2.0"
   },
   "peerDependencies": {
-    "viem": ">=2.21",
-    "wagmi": ">=2.12",
+    "viem": ">=2.23",
+    "wagmi": ">=2.14",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/core-react/CHANGELOG.md
+++ b/packages/core-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/core-react
 
+## 6.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 6.0.0
 
 ### Major Changes

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -44,8 +44,8 @@
     "@reef-knot/wallets-helpers": "^2.1.1",
     "eslint-config-custom": "*",
     "react": "18.2.0",
-    "viem": ">=2.21",
-    "wagmi": ">=2.12",
+    "viem": ">=2.23",
+    "wagmi": ">=2.14",
     "mipd": "0.0.7"
   },
   "peerDependencies": {
@@ -55,8 +55,8 @@
     "@reef-knot/ui-react": "^2.1.3",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "react": ">=18",
-    "viem": ">=2.21",
-    "wagmi": ">=2.12",
+    "viem": ">=2.23",
+    "wagmi": ">=2.14",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/core-react/package.json
+++ b/packages/core-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/core-react",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,11 +37,11 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/ledger-connector": "^4.1.4",
-    "@reef-knot/wallets-list": "^4.0.0",
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/ui-react": "^2.1.5",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/ledger-connector": "^4.3.0",
+    "@reef-knot/wallets-list": "^4.1.2",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/ui-react": "^2.2.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "eslint-config-custom": "*",
     "react": "18.2.0",
     "viem": ">=2.23",

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,23 @@
 # reef-knot
 
+## 7.2.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/ledger-connector@4.3.0
+  - @reef-knot/connect-wallet-modal@7.2.0
+  - @reef-knot/wallets-helpers@2.2.0
+  - @reef-knot/core-react@6.1.0
+  - @reef-knot/web3-react@6.1.0
+  - @reef-knot/ui-react@2.2.0
+  - @reef-knot/types@4.1.0
+  - @reef-knot/wallets-list@4.1.2
+
 ## 7.1.1
 
 ### Patch Changes

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -56,8 +56,8 @@
     "react": ">=18",
     "react-dom": ">=18",
     "styled-components": "^5.3.5",
-    "viem": ">=2.21",
-    "wagmi": ">=2.12"
+    "viem": ">=2.23",
+    "wagmi": ">=2.14"
   },
   "devDependencies": {
     "eslint-config-custom": "*"

--- a/packages/reef-knot/package.json
+++ b/packages/reef-knot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reef-knot",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -41,14 +41,14 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/connect-wallet-modal": "7.1.0",
-    "@reef-knot/core-react": "6.0.0",
-    "@reef-knot/web3-react": "6.0.0",
-    "@reef-knot/ui-react": "2.1.5",
-    "@reef-knot/wallets-list": "4.1.1",
-    "@reef-knot/wallets-helpers": "2.1.1",
-    "@reef-knot/types": "4.0.0",
-    "@reef-knot/ledger-connector": "4.2.0"
+    "@reef-knot/connect-wallet-modal": "7.2.0",
+    "@reef-knot/core-react": "6.1.0",
+    "@reef-knot/web3-react": "6.1.0",
+    "@reef-knot/ui-react": "2.2.0",
+    "@reef-knot/wallets-list": "4.1.2",
+    "@reef-knot/wallets-helpers": "2.2.0",
+    "@reef-knot/types": "4.1.0",
+    "@reef-knot/ledger-connector": "4.3.0"
   },
   "peerDependencies": {
     "@lidofinance/lido-ui": "^3.18.0",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/types
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/types",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "",
   "types": "dist/index.d.ts",
   "type": "module",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "react": "18.2.0",
     "wagmi": ">=2.14",
-    "@reef-knot/ui-react": "^2.1.3"
+    "@reef-knot/ui-react": "^2.2.0"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -27,12 +27,12 @@
   },
   "devDependencies": {
     "react": "18.2.0",
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/ui-react": "^2.1.3"
   },
   "peerDependencies": {
     "react": ">=18",
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/ui-react": "^2.1.3",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/ui-react/CHANGELOG.md
+++ b/packages/ui-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/ui-react
 
+## 2.2.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 2.1.5
 
 ### Patch Changes

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -48,7 +48,7 @@
     "react": ">=18",
     "react-dom": ">=18",
     "styled-components": "5",
-    "wagmi": ">=2.12"
+    "wagmi": ">=2.14"
   },
   "devDependencies": {
     "@types/react-transition-group": "4.4.2",
@@ -56,7 +56,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "styled-components": "^5.3.6",
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/ui-react/package.json
+++ b/packages/ui-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/ui-react",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets-helpers/CHANGELOG.md
+++ b/packages/wallets-helpers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallets-helpers
 
+## 2.2.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 2.1.1
 
 ### Patch Changes

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -42,11 +42,11 @@
   },
   "devDependencies": {
     "eslint-config-custom": "*",
-    "wagmi": ">=2.12"
+    "wagmi": ">=2.14"
   },
   "peerDependencies": {
     "react": ">=18",
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/packages/wallets-helpers/package.json
+++ b/packages/wallets-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-helpers",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/wallets-list/CHANGELOG.md
+++ b/packages/wallets-list/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @reef-knot/wallets-list
 
+## 4.1.2
+
+### Patch Changes
+
+- Updated dependencies
+  - @reef-knot/wallet-adapter-coinbase-smart-wallet@3.1.0
+  - @reef-knot/wallet-adapter-dapp-browser-injected@4.1.0
+  - @reef-knot/wallet-adapter-browser-extension@4.1.0
+  - @reef-knot/wallet-adapter-binance-wallet@3.1.0
+  - @reef-knot/wallet-adapter-walletconnect@4.1.0
+  - @reef-knot/wallet-adapter-ledger-live@5.1.0
+  - @reef-knot/wallet-adapter-ledger-hid@5.1.0
+  - @reef-knot/wallet-adapter-coinbase@4.1.0
+  - @reef-knot/wallet-adapter-metamask@4.1.0
+  - @reef-knot/wallet-adapter-bitkeep@4.1.0
+  - @reef-knot/wallet-adapter-imtoken@4.1.0
+  - @reef-knot/wallet-adapter-ambire@5.1.0
+  - @reef-knot/wallet-adapter-coin98@4.1.0
+  - @reef-knot/wallet-adapter-exodus@4.1.0
+  - @reef-knot/wallet-adapter-brave@4.1.0
+  - @reef-knot/wallet-adapter-trust@4.1.0
+  - @reef-knot/wallet-adapter-ctrl@1.1.0
+  - @reef-knot/wallet-adapter-safe@4.1.0
+  - @reef-knot/wallet-adapter-okx@4.1.0
+
 ## 4.1.1
 
 ### Patch Changes

--- a/packages/wallets-list/package.json
+++ b/packages/wallets-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallets-list",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -37,28 +37,28 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "dependencies": {
-    "@reef-knot/wallet-adapter-browser-extension": "4.0.0",
-    "@reef-knot/wallet-adapter-metamask": "4.0.0",
-    "@reef-knot/wallet-adapter-okx": "4.0.0",
-    "@reef-knot/wallet-adapter-exodus": "4.0.0",
-    "@reef-knot/wallet-adapter-walletconnect": "4.0.0",
-    "@reef-knot/wallet-adapter-ambire": "5.0.0",
-    "@reef-knot/wallet-adapter-binance-wallet": "3.0.0",
-    "@reef-knot/wallet-adapter-bitkeep": "4.0.0",
-    "@reef-knot/wallet-adapter-coin98": "4.0.0",
-    "@reef-knot/wallet-adapter-brave": "4.0.0",
-    "@reef-knot/wallet-adapter-imtoken": "4.0.0",
-    "@reef-knot/wallet-adapter-trust": "4.0.0",
-    "@reef-knot/wallet-adapter-ctrl": "1.0.0",
-    "@reef-knot/wallet-adapter-coinbase": "4.0.0",
-    "@reef-knot/wallet-adapter-coinbase-smart-wallet": "3.0.0",
-    "@reef-knot/wallet-adapter-ledger-hid": "5.0.0",
-    "@reef-knot/wallet-adapter-ledger-live": "5.0.0",
-    "@reef-knot/wallet-adapter-dapp-browser-injected": "4.0.0",
-    "@reef-knot/wallet-adapter-safe": "4.0.0"
+    "@reef-knot/wallet-adapter-browser-extension": "4.1.0",
+    "@reef-knot/wallet-adapter-metamask": "4.1.0",
+    "@reef-knot/wallet-adapter-okx": "4.1.0",
+    "@reef-knot/wallet-adapter-exodus": "4.1.0",
+    "@reef-knot/wallet-adapter-walletconnect": "4.1.0",
+    "@reef-knot/wallet-adapter-ambire": "5.1.0",
+    "@reef-knot/wallet-adapter-binance-wallet": "3.1.0",
+    "@reef-knot/wallet-adapter-bitkeep": "4.1.0",
+    "@reef-knot/wallet-adapter-coin98": "4.1.0",
+    "@reef-knot/wallet-adapter-brave": "4.1.0",
+    "@reef-knot/wallet-adapter-imtoken": "4.1.0",
+    "@reef-knot/wallet-adapter-trust": "4.1.0",
+    "@reef-knot/wallet-adapter-ctrl": "1.1.0",
+    "@reef-knot/wallet-adapter-coinbase": "4.1.0",
+    "@reef-knot/wallet-adapter-coinbase-smart-wallet": "3.1.0",
+    "@reef-knot/wallet-adapter-ledger-hid": "5.1.0",
+    "@reef-knot/wallet-adapter-ledger-live": "5.1.0",
+    "@reef-knot/wallet-adapter-dapp-browser-injected": "4.1.0",
+    "@reef-knot/wallet-adapter-safe": "4.1.0"
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
+    "@reef-knot/types": "^4.1.0",
     "eslint-config-custom": "*"
   },
   "peerDependencies": {

--- a/packages/wallets/ambire/CHANGELOG.md
+++ b/packages/wallets/ambire/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-ambire
 
+## 5.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 5.0.0
 
 ### Major Changes

--- a/packages/wallets/ambire/package.json
+++ b/packages/wallets/ambire/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/ambire/package.json
+++ b/packages/wallets/ambire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ambire",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/binance-wallet/CHANGELOG.md
+++ b/packages/wallets/binance-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-binance-wallet
 
+## 3.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/binance-wallet/package.json
+++ b/packages/wallets/binance-wallet/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
-    "wagmi": ">=2.12"
+    "wagmi": ">=2.14"
   },
   "dependencies": {
     "@binance/w3w-wagmi-connector-v2": "^1.2.3",

--- a/packages/wallets/binance-wallet/package.json
+++ b/packages/wallets/binance-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-binance-wallet",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.0.0",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/bitkeep/CHANGELOG.md
+++ b/packages/wallets/bitkeep/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-bitkeep
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/bitkeep/package.json
+++ b/packages/wallets/bitkeep/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/bitkeep/package.json
+++ b/packages/wallets/bitkeep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-bitkeep",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/brave/CHANGELOG.md
+++ b/packages/wallets/brave/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-brave
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/brave/package.json
+++ b/packages/wallets/brave/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/brave/package.json
+++ b/packages/wallets/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-brave",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/browserExtension/CHANGELOG.md
+++ b/packages/wallets/browserExtension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-browser-extension
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/browserExtension/package.json
+++ b/packages/wallets/browserExtension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-browser-extension",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
+    "@reef-knot/types": "^4.1.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/browserExtension/package.json
+++ b/packages/wallets/browserExtension/package.json
@@ -37,7 +37,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/coin98/CHANGELOG.md
+++ b/packages/wallets/coin98/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-coin98
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/coin98/package.json
+++ b/packages/wallets/coin98/package.json
@@ -37,7 +37,7 @@
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/coin98/package.json
+++ b/packages/wallets/coin98/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coin98",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1"
   },
   "peerDependencies": {

--- a/packages/wallets/coinbase-smart-wallet/CHANGELOG.md
+++ b/packages/wallets/coinbase-smart-wallet/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-coinbase-smart-wallet
 
+## 3.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 3.0.0
 
 ### Patch Changes

--- a/packages/wallets/coinbase-smart-wallet/package.json
+++ b/packages/wallets/coinbase-smart-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coinbase-smart-wallet",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
+    "@reef-knot/types": "^4.1.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/coinbase-smart-wallet/package.json
+++ b/packages/wallets/coinbase-smart-wallet/package.json
@@ -37,7 +37,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/coinbase/CHANGELOG.md
+++ b/packages/wallets/coinbase/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-coinbase
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/coinbase/package.json
+++ b/packages/wallets/coinbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-coinbase",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/coinbase/package.json
+++ b/packages/wallets/coinbase/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/ctrl/CHANGELOG.md
+++ b/packages/wallets/ctrl/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @reef-knot/wallet-adapter-ctrl
+
+## 1.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue

--- a/packages/wallets/ctrl/package.json
+++ b/packages/wallets/ctrl/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2"
   }

--- a/packages/wallets/ctrl/package.json
+++ b/packages/wallets/ctrl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ctrl",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/dappBrowserInjected/CHANGELOG.md
+++ b/packages/wallets/dappBrowserInjected/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-dapp-browser-injected
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/dappBrowserInjected/package.json
+++ b/packages/wallets/dappBrowserInjected/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/dappBrowserInjected/package.json
+++ b/packages/wallets/dappBrowserInjected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-dapp-browser-injected",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/exodus/CHANGELOG.md
+++ b/packages/wallets/exodus/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-exodus
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-exodus",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/imtoken/CHANGELOG.md
+++ b/packages/wallets/imtoken/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-imtoken
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/imtoken/package.json
+++ b/packages/wallets/imtoken/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-imtoken",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
+    "@reef-knot/types": "^4.1.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/imtoken/package.json
+++ b/packages/wallets/imtoken/package.json
@@ -37,7 +37,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/ledger-hid/CHANGELOG.md
+++ b/packages/wallets/ledger-hid/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-ledger-hid
 
+## 5.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 5.0.0
 
 ### Patch Changes

--- a/packages/wallets/ledger-hid/package.json
+++ b/packages/wallets/ledger-hid/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/ledger-connector": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/ledger-hid/package.json
+++ b/packages/wallets/ledger-hid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ledger-hid",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/ledger-connector": "^4.1.4",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/ledger-connector": "^4.3.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/ledger-live/CHANGELOG.md
+++ b/packages/wallets/ledger-live/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-ledger-live
 
+## 5.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 5.0.0
 
 ### Patch Changes

--- a/packages/wallets/ledger-live/package.json
+++ b/packages/wallets/ledger-live/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/ledger-connector": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/ledger-live/package.json
+++ b/packages/wallets/ledger-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-ledger-live",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/ledger-connector": "^4.1.4",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/ledger-connector": "^4.3.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/metamask/CHANGELOG.md
+++ b/packages/wallets/metamask/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-metamask
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/metamask/package.json
+++ b/packages/wallets/metamask/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/metamask/package.json
+++ b/packages/wallets/metamask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-metamask",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/okx/CHANGELOG.md
+++ b/packages/wallets/okx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-okx
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-okx",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/phantom/CHANGELOG.md
+++ b/packages/wallets/phantom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-phantom
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-phantom",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/safe/CHANGELOG.md
+++ b/packages/wallets/safe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-safe
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/safe/package.json
+++ b/packages/wallets/safe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-safe",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,7 +32,7 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
+    "@reef-knot/types": "^4.1.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/safe/package.json
+++ b/packages/wallets/safe/package.json
@@ -37,8 +37,8 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "viem": ">=2.21",
-    "wagmi": ">=2.12",
+    "viem": ">=2.23",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"
   }

--- a/packages/wallets/trust/CHANGELOG.md
+++ b/packages/wallets/trust/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-trust
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/trust/package.json
+++ b/packages/wallets/trust/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/trust/package.json
+++ b/packages/wallets/trust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-trust",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/walletconnect/CHANGELOG.md
+++ b/packages/wallets/walletconnect/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-walletconnect
 
+## 4.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.0.0
 
 ### Patch Changes

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "@reef-knot/types": "^4.0.0",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-walletconnect",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/wallets/xdefi/CHANGELOG.md
+++ b/packages/wallets/xdefi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/wallet-adapter-xdefi
 
+## 4.2.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/wallets/xdefi/package.json
+++ b/packages/wallets/xdefi/package.json
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2",
     "@tanstack/react-query": "^5.29.0"

--- a/packages/wallets/xdefi/package.json
+++ b/packages/wallets/xdefi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/wallet-adapter-xdefi",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -32,8 +32,8 @@
     "lint": "eslint --ext ts,tsx,js,mjs ."
   },
   "devDependencies": {
-    "@reef-knot/types": "^4.0.0",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/types": "^4.1.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@svgr/rollup": "^6.5.1",
     "eslint-config-custom": "*"
   },

--- a/packages/web3-react/CHANGELOG.md
+++ b/packages/web3-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @reef-knot/web3-react
 
+## 6.1.0
+
+### Minor Changes
+
+- Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes a dependabot issue
+
 ## 6.0.0
 
 ### Patch Changes

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reef-knot/web3-react",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -46,9 +46,9 @@
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.18.6",
     "@ethersproject/providers": "^5.7.2",
-    "@reef-knot/core-react": "^6.0.0",
-    "@reef-knot/ledger-connector": "^4.1.4",
-    "@reef-knot/wallets-helpers": "^2.1.1",
+    "@reef-knot/core-react": "^6.1.0",
+    "@reef-knot/ledger-connector": "^4.3.0",
+    "@reef-knot/wallets-helpers": "^2.2.0",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/react": "18.2.45",

--- a/packages/web3-react/package.json
+++ b/packages/web3-react/package.json
@@ -66,7 +66,7 @@
     "@reef-knot/ledger-connector": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.0",
     "react": ">=18",
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@tanstack/react-query": "^5.29.0"
   }
 }

--- a/turbo/generators/wallet/templates/package.json.hbs
+++ b/turbo/generators/wallet/templates/package.json.hbs
@@ -38,7 +38,7 @@
     "eslint-config-custom": "*"
   },
   "peerDependencies": {
-    "wagmi": ">=2.12",
+    "wagmi": ">=2.14",
     "@reef-knot/types": "^4.0.0",
     "@reef-knot/wallets-helpers": "^2.0.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@adraffy/ens-normalize@1.11.0":
+"@adraffy/ens-normalize@1.11.0", "@adraffy/ens-normalize@^1.10.1":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
   integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
@@ -1525,17 +1525,10 @@
     core-js-pure "^3.30.2"
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.20.1", "@babel/runtime@^7.23.2", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.20.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.23.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
   integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.19.4", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0":
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.0.tgz#3af9a91c1b739c569d5d80cc917280919c544ecb"
-  integrity sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -1543,6 +1536,20 @@
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.9.tgz#47791a15e4603bb5f905bc0753801cf21d6345f7"
   integrity sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0":
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.0.tgz#3af9a91c1b739c569d5d80cc917280919c544ecb"
+  integrity sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.26.0":
+  version "7.26.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.7.tgz#f4e7fe527cd710f8dc0618610b61b4b060c3c341"
+  integrity sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -1914,15 +1921,15 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@coinbase/wallet-sdk@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-4.1.0.tgz#3224a102b724dcb1a63005f371d596ae2999953b"
-  integrity sha512-SkJJ72X/AA3+aS21sPs/4o4t6RVeDSA7HuBW4zauySX3eBiPU0zmVw95tXH/eNSX50agKz9WzeN8P5F+HcwLOw==
+"@coinbase/wallet-sdk@4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@coinbase/wallet-sdk/-/wallet-sdk-4.3.0.tgz#03b8fce92ac2b3b7cf132f64d6008ac081569b4e"
+  integrity sha512-T3+SNmiCw4HzDm4we9wCHCxlP0pqCiwKe4sOwPH3YAK2KSKjxPRydKu6UQJrdONFVLG7ujXvbd/6ZqmvJb8rkw==
   dependencies:
     "@noble/hashes" "^1.4.0"
     clsx "^1.2.1"
     eventemitter3 "^5.0.1"
-    preact "^10.16.0"
+    preact "^10.24.2"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -1936,10 +1943,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@ecies/ciphers@^0.2.0":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@ecies/ciphers/-/ciphers-0.2.1.tgz#a3119516fb55d27ed2d21c497b1c4988f0b4ca02"
-  integrity sha512-ezMihhjW24VNK/2qQR7lH8xCQY24nk0XHF/kwJ1OuiiY5iEwQXOcKVSy47fSoHPRG8gVGXcK5SgtONDk5xMwtQ==
+"@ecies/ciphers@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@ecies/ciphers/-/ciphers-0.2.2.tgz#82a15b10a6e502b63fb30915d944b2eaf3ff17ff"
+  integrity sha512-ylfGR7PyTd+Rm2PqQowG08BCKA22QuX8NzrL+LxAAvazN10DMwdJ2fWwAzRj05FI/M8vNFGm3cv9Wq/GFWCBLg==
 
 "@emotion/is-prop-valid@^0.8.1":
   version "0.8.8"
@@ -2814,10 +2821,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.1.tgz#e89b840a7af8097a8ed4953d8dc8470d1302d3ef"
   integrity sha512-ihb3B0T/wJm1eUuArYP4lCTSEoZsClHhuWyfo/kMX3m/odpqNcPfsz5O2A3NT7dXCAgWPGDQGPqygCpgeniKMw==
 
-"@metamask/sdk-communication-layer@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.30.0.tgz#2bd252cfce3ac4260a6c8c9359732ab5e839b75e"
-  integrity sha512-q5nbdYkAf76MsZxi1l5MJEAyd8sY9jLRapC8a7x1Q1BNV4rzQeFeux/d0mJ/jTR2LAwbnLZs2rL226AM75oK4w==
+"@metamask/sdk-communication-layer@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@metamask/sdk-communication-layer/-/sdk-communication-layer-0.32.0.tgz#89710e807806836138ea5018b087731d6acab627"
+  integrity sha512-dmj/KFjMi1fsdZGIOtbhxdg3amxhKL/A5BqSU4uh/SyDKPub/OT+x5pX8bGjpTL1WPWY/Q0OIlvFyX3VWnT06Q==
   dependencies:
     bufferutil "^4.0.8"
     date-fns "^2.29.3"
@@ -2825,36 +2832,35 @@
     utf-8-validate "^5.0.2"
     uuid "^8.3.2"
 
-"@metamask/sdk-install-modal-web@0.30.0":
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/@metamask/sdk-install-modal-web/-/sdk-install-modal-web-0.30.0.tgz#9ec634201b1b47bb30064f42ae0efba7f204bb0a"
-  integrity sha512-1gT533Huja9tK3cmttvcpZirRAtWJ7vnYH+lnNRKEj2xIP335Df2cOwS+zqNC4GlRCZw7A3IsTjIzlKoxBY1uQ==
+"@metamask/sdk-install-modal-web@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@metamask/sdk-install-modal-web/-/sdk-install-modal-web-0.32.0.tgz#86f80420ca364fa0d7710016fa5c81f95537ab23"
+  integrity sha512-TFoktj0JgfWnQaL3yFkApqNwcaqJ+dw4xcnrJueMP3aXkSNev2Ido+WVNOg4IIMxnmOrfAC9t0UJ0u/dC9MjOQ==
   dependencies:
-    qr-code-styling "^1.6.0-rc.1"
+    "@paulmillr/qr" "^0.2.1"
 
-"@metamask/sdk@0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@metamask/sdk/-/sdk-0.30.1.tgz#63126ad769566098000cc3c2cd513d18808471f3"
-  integrity sha512-NelEjJZsF5wVpSQELpmvXtnS9+C6HdxGQ4GB9jMRzeejphmPyKqmrIGM6XtaPrJtlpX+40AcJ2dtBQcjJVzpbQ==
+"@metamask/sdk@0.32.0":
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/@metamask/sdk/-/sdk-0.32.0.tgz#f0e179746fe69dccd032a9026884b45b519c1975"
+  integrity sha512-WmGAlP1oBuD9hk4CsdlG1WJFuPtYJY+dnTHJMeCyohTWD2GgkcLMUUuvu9lO1/NVzuOoSi1OrnjbuY1O/1NZ1g==
   dependencies:
+    "@babel/runtime" "^7.26.0"
     "@metamask/onboarding" "^1.0.1"
     "@metamask/providers" "16.1.0"
-    "@metamask/sdk-communication-layer" "0.30.0"
-    "@metamask/sdk-install-modal-web" "0.30.0"
+    "@metamask/sdk-communication-layer" "0.32.0"
+    "@metamask/sdk-install-modal-web" "0.32.0"
+    "@paulmillr/qr" "^0.2.1"
     bowser "^2.9.0"
     cross-fetch "^4.0.0"
     debug "^4.3.4"
-    eciesjs "^0.4.8"
+    eciesjs "^0.4.11"
     eth-rpc-errors "^4.0.3"
-    eventemitter2 "^6.4.7"
-    i18next "23.11.5"
-    i18next-browser-languagedetector "7.1.0"
+    eventemitter2 "^6.4.9"
     obj-multiplex "^1.0.0"
     pump "^3.0.0"
-    qrcode-terminal-nooctal "^0.12.1"
-    react-native-webview "^11.26.0"
     readable-stream "^3.6.2"
     socket.io-client "^4.5.1"
+    tslib "^2.6.0"
     util "^0.12.4"
     uuid "^8.3.2"
 
@@ -3081,6 +3087,13 @@
   dependencies:
     "@noble/hashes" "1.5.0"
 
+"@noble/curves@1.8.1", "@noble/curves@~1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.8.1.tgz#19bc3970e205c99e4bdb1c64a4785706bce497ff"
+  integrity sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==
+  dependencies:
+    "@noble/hashes" "1.7.1"
+
 "@noble/hashes@1.4.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@~1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
@@ -3090,6 +3103,11 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
   integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
+
+"@noble/hashes@1.7.1", "@noble/hashes@~1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
+  integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3204,6 +3222,11 @@
     "@parcel/watcher-win32-ia32" "2.4.0"
     "@parcel/watcher-win32-x64" "2.4.0"
 
+"@paulmillr/qr@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@paulmillr/qr/-/qr-0.2.1.tgz#76ade7080be4ac4824f638146fd8b6db1805eeca"
+  integrity sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==
+
 "@pedrouid/environment@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@pedrouid/environment/-/environment-1.0.1.tgz#858f0f8a057340e0b250398b75ead77d6f4342ec"
@@ -3290,10 +3313,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@safe-global/safe-apps-provider@0.18.3":
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.3.tgz#805a42e24f5dde803cb96dac251a3c9e256de45b"
-  integrity sha512-f/0cNv3S4v7p8rowAjj0hDCg8Q8P/wBjp5twkNWeBdvd0RDr7BuRBPPk74LCqmjQ82P+1ltLlkmVFSmxTIT7XQ==
+"@safe-global/safe-apps-provider@0.18.5":
+  version "0.18.5"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.5.tgz#745a932bda3739a8a298ae44ec6c465f6c4773b7"
+  integrity sha512-9v9wjBi3TwLsEJ3C2ujYoexp3pFJ0omDLH/GX91e2QB+uwCKTBYyhxFSrTQ9qzoyQd+bfsk4gjOGW87QcJhf7g==
   dependencies:
     "@safe-global/safe-apps-sdk" "^9.1.0"
     events "^3.3.0"
@@ -3321,6 +3344,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
   integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
 
+"@scure/base@~1.2.2", "@scure/base@~1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.4.tgz#002eb571a35d69bdb4c214d0995dff76a8dcd2a9"
+  integrity sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==
+
 "@scure/bip32@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
@@ -3339,6 +3367,15 @@
     "@noble/hashes" "~1.5.0"
     "@scure/base" "~1.1.7"
 
+"@scure/bip32@1.6.2", "@scure/bip32@^1.5.0":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.6.2.tgz#093caa94961619927659ed0e711a6e4bf35bffd0"
+  integrity sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==
+  dependencies:
+    "@noble/curves" "~1.8.1"
+    "@noble/hashes" "~1.7.1"
+    "@scure/base" "~1.2.2"
+
 "@scure/bip39@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
@@ -3354,6 +3391,14 @@
   dependencies:
     "@noble/hashes" "~1.5.0"
     "@scure/base" "~1.1.8"
+
+"@scure/bip39@1.5.4", "@scure/bip39@^1.4.0":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.5.4.tgz#07fd920423aa671be4540d59bdd344cc1461db51"
+  integrity sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==
+  dependencies:
+    "@noble/hashes" "~1.7.1"
+    "@scure/base" "~1.2.4"
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.2"
@@ -4274,22 +4319,22 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@wagmi/connectors@5.3.3":
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/@wagmi/connectors/-/connectors-5.3.3.tgz#ef823eeebeaa72852c0e5176bc5308f5cb8699ec"
-  integrity sha512-RUgwgqX7H+qg1lXBhLqcG0D5xb8USlAv4MVai4r5YpRw6lxpDvELFXxHN4ldZuUARKhH7Q3ZpfvdWyEXY+wn9w==
+"@wagmi/connectors@5.7.7":
+  version "5.7.7"
+  resolved "https://registry.yarnpkg.com/@wagmi/connectors/-/connectors-5.7.7.tgz#35fe03d69ca3f1494c0e97a758884e06e535eefd"
+  integrity sha512-hveKxuR35ZQQyteLo7aiN/TBVECYKVbLNTYGGgqzTNHJ8vVoblTP9PwPrRPGOPi5ji8raYSFWShxNK7QpGL+Kg==
   dependencies:
-    "@coinbase/wallet-sdk" "4.1.0"
-    "@metamask/sdk" "0.30.1"
-    "@safe-global/safe-apps-provider" "0.18.3"
+    "@coinbase/wallet-sdk" "4.3.0"
+    "@metamask/sdk" "0.32.0"
+    "@safe-global/safe-apps-provider" "0.18.5"
     "@safe-global/safe-apps-sdk" "9.1.0"
     "@walletconnect/ethereum-provider" "2.17.0"
     cbw-sdk "npm:@coinbase/wallet-sdk@3.9.3"
 
-"@wagmi/core@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/@wagmi/core/-/core-2.14.1.tgz#e6adb8a350cfd7be4ea9c5581768f951c60127de"
-  integrity sha512-Vl7VK5XdKxPfnYlp3E7U7AJSweBdfh+cd953hgAU2H+uNrekS9Nmt89l1b6WkwkYyqvccRDjsCtlcKRwvPtNAQ==
+"@wagmi/core@2.16.4":
+  version "2.16.4"
+  resolved "https://registry.yarnpkg.com/@wagmi/core/-/core-2.16.4.tgz#96f1a2803dbf3ca110938402bdf2d99ab8da638e"
+  integrity sha512-E4jY4A98gwuHCjzuEajHIG/WhNDY5BChVHMjflV9Bx5CO7COqYRG2dcRLuF6Bo0LQNvVvXDAFUwR2JShJnT5pA==
   dependencies:
     eventemitter3 "5.0.1"
     mipd "0.0.7"
@@ -4581,6 +4626,11 @@ abitype@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.6.tgz#76410903e1d88e34f1362746e2d407513c38565b"
   integrity sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==
+
+abitype@1.0.8, abitype@^1.0.6:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.8.tgz#3554f28b2e9d6e9f35eb59878193eabd1b9f46ba"
+  integrity sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -6200,12 +6250,12 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-eciesjs@^0.4.8:
-  version "0.4.10"
-  resolved "https://registry.yarnpkg.com/eciesjs/-/eciesjs-0.4.10.tgz#7548ae8385809d1b81529ebe48b87d8549941270"
-  integrity sha512-dYAgdXAC7/d9fEC0w6kpRWj5vHah2BQgMM639g78JI0FUUffMN2Mq60HEHPkyH8ah+FX+cQd6ouDK4kWiatzyw==
+eciesjs@^0.4.11:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/eciesjs/-/eciesjs-0.4.13.tgz#89fbe2bc37d6dced8c3d1bccac21cceb20bcdcf3"
+  integrity sha512-zBdtR4K+wbj10bWPpIOF9DW+eFYQu8miU5ypunh0t4Bvt83ZPlEWgT5Dq/0G6uwEXumZKjfb5BZxYUZQ2Hzn/Q==
   dependencies:
-    "@ecies/ciphers" "^0.2.0"
+    "@ecies/ciphers" "^0.2.2"
     "@noble/ciphers" "^1.0.0"
     "@noble/curves" "^1.6.0"
     "@noble/hashes" "^1.5.0"
@@ -6520,11 +6570,6 @@ escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
-
-escape-string-regexp@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -6948,7 +6993,7 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
-eventemitter2@^6.4.7:
+eventemitter2@^6.4.9:
   version "6.4.9"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.9.tgz#41f2750781b4230ed58827bc119d293471ecb125"
   integrity sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==
@@ -7711,20 +7756,6 @@ husky@^8.0.3:
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
-i18next-browser-languagedetector@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.1.0.tgz#01876fac51f86b78975e79b48ccb62e2313a2d7d"
-  integrity sha512-cr2k7u1XJJ4HTOjM9GyOMtbOA47RtUoWRAtt52z43r3AoMs2StYKyjS3URPhzHaf+mn10hY9dZWamga5WPQjhA==
-  dependencies:
-    "@babel/runtime" "^7.19.4"
-
-i18next@23.11.5:
-  version "23.11.5"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.11.5.tgz#d71eb717a7e65498d87d0594f2664237f9e361ef"
-  integrity sha512-41pvpVbW9rhZPk5xjCX2TPJi2861LEig/YRhUkY+1FQ2IQPS0bKUDYnEqY8XPPbB48h1uIwLnP9iiEfuSl20CA==
-  dependencies:
-    "@babel/runtime" "^7.23.2"
-
 iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -7846,7 +7877,7 @@ internal-slot@^1.0.7:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
-invariant@2, invariant@2.2.4:
+invariant@2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -9314,6 +9345,19 @@ outdent@^0.5.0:
   resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.5.0.tgz#9e10982fdc41492bb473ad13840d22f9655be2ff"
   integrity sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==
 
+ox@0.6.7:
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.6.7.tgz#afd53f2ecef68b8526660e9d29dee6e6b599a832"
+  integrity sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.10.1"
+    "@noble/curves" "^1.6.0"
+    "@noble/hashes" "^1.5.0"
+    "@scure/bip32" "^1.5.0"
+    "@scure/bip39" "^1.4.0"
+    abitype "^1.0.6"
+    eventemitter3 "5.0.1"
+
 p-filter@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-filter/-/p-filter-2.1.0.tgz#1b1472562ae7a0f742f0f3d3d3718ea66ff9c09c"
@@ -9654,6 +9698,11 @@ preact@^10.16.0:
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.23.1.tgz#d400107289bc979881c5212cb5f5cd22cd1dc38c"
   integrity sha512-O5UdRsNh4vdZaTieWe3XOgSpdMAmkIYBCT3VhQDlKrzyCm8lUYsk0fmVEvoQQifoOjFRTaHZO69ylrzTW2BH+A==
 
+preact@^10.24.2:
+  version "10.25.4"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.25.4.tgz#c1d00bee9d7b9dcd06a2311d9951973b506ae8ac"
+  integrity sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==
+
 preferred-pm@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.1.2.tgz#aedb70550734a574dffcbf2ce82642bd1753bdd6"
@@ -9772,23 +9821,6 @@ pure-color@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
   integrity sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA==
-
-qr-code-styling@^1.6.0-rc.1:
-  version "1.6.0-rc.1"
-  resolved "https://registry.yarnpkg.com/qr-code-styling/-/qr-code-styling-1.6.0-rc.1.tgz#6c89e185fa50cc9135101085c12ae95b06f1b290"
-  integrity sha512-ModRIiW6oUnsP18QzrRYZSc/CFKFKIdj7pUs57AEVH20ajlglRpN3HukjHk0UbNMTlKGuaYl7Gt6/O5Gg2NU2Q==
-  dependencies:
-    qrcode-generator "^1.4.3"
-
-qrcode-generator@^1.4.3:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/qrcode-generator/-/qrcode-generator-1.4.4.tgz#63f771224854759329a99048806a53ed278740e7"
-  integrity sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw==
-
-qrcode-terminal-nooctal@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/qrcode-terminal-nooctal/-/qrcode-terminal-nooctal-0.12.1.tgz#45016aca0d82b2818de7af0a06d072ad671fbe2e"
-  integrity sha512-jy/kkD0iIMDjTucB+5T6KBsnirlhegDH47vHgrj5MejchSQmi/EAMM0xMFeePgV9CJkkAapNakpVUWYgHvtdKg==
 
 qrcode.react@^3.1.0:
   version "3.1.0"
@@ -9925,14 +9957,6 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
-react-native-webview@^11.26.0:
-  version "11.26.1"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.26.1.tgz#658c09ed5162dc170b361e48c2dd26c9712879da"
-  integrity sha512-hC7BkxOpf+z0UKhxFSFTPAM4shQzYmZHoELa6/8a/MspcjEP7ukYKpuSUTLDywQditT8yI9idfcKvfZDKQExGw==
-  dependencies:
-    escape-string-regexp "2.0.0"
-    invariant "2.2.4"
 
 react-textarea-autosize@^8.3.2:
   version "8.5.3"
@@ -10757,16 +10781,7 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10862,14 +10877,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11274,6 +11282,11 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.6.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -11692,6 +11705,11 @@ use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
+use-sync-external-store@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz#adbc795d8eeb47029963016cefdf89dc799fcebc"
+  integrity sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==
+
 utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
@@ -11758,19 +11776,18 @@ valtio@1.11.2:
     proxy-compare "2.5.1"
     use-sync-external-store "1.2.0"
 
-viem@>=2.21, viem@^2.21.37:
-  version "2.21.37"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.37.tgz#4d67bee8749321b0fd142c54df2021d5774403b1"
-  integrity sha512-JupwyttT4aJNnP9+kD7E8jorMS5VmgpC3hm3rl5zXsO8WNBTsP3JJqZUSg4AG6s2lTrmmpzS/qpmXMZu5gJw5Q==
+viem@>=2.23, viem@^2.23.1:
+  version "2.23.1"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.23.1.tgz#5fe527de258e33b2445af266698fd6575068112d"
+  integrity sha512-c5AyJCTA5LeNI/KCu++vkbqbh7irYjUSHxLIAHPKJ6IEcBNMt8+7sPG7gjMXpqVWnqPMzaW9CA2n+yUsKWttDA==
   dependencies:
-    "@adraffy/ens-normalize" "1.11.0"
-    "@noble/curves" "1.6.0"
-    "@noble/hashes" "1.5.0"
-    "@scure/bip32" "1.5.0"
-    "@scure/bip39" "1.4.0"
-    abitype "1.0.6"
+    "@noble/curves" "1.8.1"
+    "@noble/hashes" "1.7.1"
+    "@scure/bip32" "1.6.2"
+    "@scure/bip39" "1.5.4"
+    abitype "1.0.8"
     isows "1.0.6"
-    webauthn-p256 "0.0.10"
+    ox "0.6.7"
     ws "8.18.0"
 
 viem@^2.1.1:
@@ -11788,14 +11805,14 @@ viem@^2.1.1:
     webauthn-p256 "0.0.10"
     ws "8.18.0"
 
-wagmi@>=2.12, wagmi@^2.12.25:
-  version "2.12.25"
-  resolved "https://registry.yarnpkg.com/wagmi/-/wagmi-2.12.25.tgz#0e4f23a96e021143f202c250ec0af3a5ea0cca08"
-  integrity sha512-RdQCDbTv1+b7fWCAoLEYX0loymqLnhmNrMZq1gfPEs6cOhEHYOQeZtJWnyaXOD5+3xIFw+xoA0xDNvAHVbtbKw==
+wagmi@>=2.14, wagmi@^2.14.11:
+  version "2.14.11"
+  resolved "https://registry.yarnpkg.com/wagmi/-/wagmi-2.14.11.tgz#bfdd479e88bb3907efb412d04b5135a0017d5090"
+  integrity sha512-Qj79cq+9MAcnKict9QLo60Lc4S2IXVVE94HBwCmczDrFtoM31NxfX4uQP73Elj2fV9lXH4/dw3jlb8eDhlm6iQ==
   dependencies:
-    "@wagmi/connectors" "5.3.3"
-    "@wagmi/core" "2.14.1"
-    use-sync-external-store "1.2.0"
+    "@wagmi/connectors" "5.7.7"
+    "@wagmi/core" "2.16.4"
+    use-sync-external-store "1.4.0"
 
 wcwidth@^1.0.1:
   version "1.0.1"
@@ -11955,7 +11972,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11968,15 +11985,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Update viem to v2.23 and wagmi to v2.14, so the @coinbase/wallet-sdk would be updated too, which fixes this dependabot issue: https://github.com/lidofinance/reef-knot/security/dependabot/75