### PR TITLE
Set yarn version during workflows

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -27,6 +27,11 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
+      - name: Enable Corepack and set Yarn version
+        run: |
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -33,6 +33,11 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
+      - name: Enable Corepack and set Yarn version
+        run: |
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
+
       - name: Install dependencies
         run: yarn --immutable
 

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -25,6 +25,11 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
+      - name: Enable Corepack and set Yarn version
+        run: |
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
+
       - name: Install dependencies
         run: yarn --immutable
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
+      - name: Enable Corepack and set Yarn version
+        run: |
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
+
       - name: Install dependencies
         run: yarn --immutable
 


### PR DESCRIPTION
Without this fix, the workflows are trying to use yarn v1, but we need v4.