### PR TITLE
Fix publish-dry-run workflow

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -8,6 +8,10 @@ on:
         description: 'NPM token'
         required: true
 
+permissions:
+  contents: write # to be able to publish a GitHub release
+  id-token: write # to enable use of OIDC for npm provenance
+
 jobs:
   publish-dry-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should fix `EGITNOPERMISSION Cannot push to the Git repository.` error.
See https://github.com/lidofinance/reef-knot/actions/runs/13704902462/job/38327716938