### PR TITLE
Add onAutoConnect, onReconnect

### DIFF
--- a/apps/demo-react/utils/metrics.ts
+++ b/apps/demo-react/utils/metrics.ts
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
-import type { ReefKnotWalletsModalConfig } from '@reef-knot/types';
+import type {
+  ReefKnotWalletsModalConfig,
+  ReefKnotConfig,
+} from '@reef-knot/types';
 import type { WalletIdsEthereum } from '@reef-knot/wallets-list';
 
 type MetricProps = Pick<
@@ -9,7 +12,8 @@ type MetricProps = Pick<
   | 'onClickWalletsLess'
   | 'onConnectStart'
   | 'onConnectSuccess'
->;
+> &
+  Pick<ReefKnotConfig, 'onAutoConnect' | 'onReconnect'>;
 
 export const metricProps: MetricProps = {
   onClickTermsAccept: ({ isAccepted }) => {
@@ -20,4 +24,6 @@ export const metricProps: MetricProps = {
   onConnectStart: ({ walletId }) => console.log(`metrics: ${walletId} clicked`),
   onConnectSuccess: ({ walletId }) =>
     console.log(`metrics: ${walletId} connected`),
+  onAutoConnect: () => console.log(`metrics: onAutoConnect called`),
+  onReconnect: () => console.log(`metrics: onReconnect called`),
 };

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerAccountScreen.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerAccountScreen.tsx
@@ -78,7 +78,13 @@ export const LedgerAccountScreen: FC<Props> = ({ onConnectSuccess }) => {
         setError(helpers.interceptLedgerError(e as Error));
       }
     },
-    [disconnectTransport, walletDataList, setError, onConnectSuccess],
+    [
+      disconnectTransport,
+      walletDataList,
+      setError,
+      connectAsync,
+      onConnectSuccess,
+    ],
   );
 
   const handleDerivationPathSelect = useCallback((value: string) => {

--- a/packages/connect-wallet-modal/src/components/Ledger/LedgerContext.tsx
+++ b/packages/connect-wallet-modal/src/components/Ledger/LedgerContext.tsx
@@ -114,7 +114,7 @@ export const LedgerContextProvider = ({
     } finally {
       isTransportConnecting.current = false;
     }
-  }, [disconnectTransport]);
+  }, [disconnectTransport, loadLedgerLibs]);
 
   const reconnectTransport = useCallback(async () => {
     await disconnectTransport(true);

--- a/packages/core-react/src/context/reefKnotContext.ts
+++ b/packages/core-react/src/context/reefKnotContext.ts
@@ -1,18 +1,15 @@
 import { createContext } from 'react';
-import type { WalletAdapterData } from '@reef-knot/types';
+import type { ReefKnotContextValue } from '@reef-knot/types';
+
+// re-export config types from @reef-knot/types for legacy reasons
+export type {
+  ReefKnotConfig,
+  ReefKnotProviderConfig,
+  ReefKnotContextValue,
+} from '@reef-knot/types';
 
 /**
  * Context definition is in separated file to avoid circular dependencies
  */
-
-export type ReefKnotProviderConfig = {
-  autoConnect: boolean;
-  walletDataList: WalletAdapterData[];
-};
-
-export type ReefKnotContextValue = ReefKnotProviderConfig & {
-  loadingWalletId: string | null;
-  setLoadingWalletId: React.Dispatch<React.SetStateAction<string | null>>;
-};
 
 export const ReefKnotContext = createContext({} as ReefKnotContextValue);

--- a/packages/core-react/src/helpers/getDefaultConfig.ts
+++ b/packages/core-react/src/helpers/getDefaultConfig.ts
@@ -1,11 +1,14 @@
 import { http, Chain, Transport } from 'viem';
 import { createConfig } from 'wagmi';
-import type { ReefKnotWalletsModalConfig } from '@reef-knot/types';
+import type {
+  ReefKnotWalletsModalConfig,
+  ReefKnotProviderConfig,
+  ReefKnotConfig,
+} from '@reef-knot/types';
 import {
   getWalletsDataList,
   GetWalletsDataListArgs,
 } from './getWalletsDataList';
-import type { ReefKnotProviderConfig } from '../context/reefKnotContext';
 
 type RpcMap = Record<number, string>;
 type Transports = Record<number, Transport>;
@@ -20,12 +23,10 @@ type WagmiConfigArgs = Omit<
   'connectors' | 'client'
 >;
 
-type DefaultConfigArgs<I extends string = string> =
+type DefaultConfigArgs<I extends string = string> = ReefKnotConfig &
   ReefKnotWalletsModalConfig<I> &
-    GetWalletsDataListArgs &
-    WagmiConfigArgs & {
-      autoConnect: boolean;
-    };
+  GetWalletsDataListArgs &
+  WagmiConfigArgs;
 
 const getDefaultTransports = (chains: Chains, rpc: RpcMap) =>
   chains.reduce<Transports>(
@@ -46,6 +47,8 @@ export const getDefaultConfig = <I extends string = string>({
   chains,
   transports,
   autoConnect,
+  onAutoConnect,
+  onReconnect,
 
   // Wallets config args
   buttonComponentsByConnectorId,
@@ -75,6 +78,8 @@ export const getDefaultConfig = <I extends string = string>({
   const reefKnotConfig: ReefKnotProviderConfig = {
     autoConnect,
     walletDataList: walletsDataList,
+    onAutoConnect,
+    onReconnect,
   };
 
   const wagmiConfig = createConfig({

--- a/packages/core-react/src/helpers/withCallback.ts
+++ b/packages/core-react/src/helpers/withCallback.ts
@@ -1,14 +1,14 @@
 // Utility to wrap a function and call a callback after the function call
-export function wrapWithCallback<
+export function withCallback<
   T extends (...args: any[]) => any,
-  C extends (...args: any[]) => void,
+  C extends ((...args: any[]) => void) | undefined,
 >(
   fn: T,
   callback: C,
 ): (...args: Parameters<T>) => ReturnType<T> | Promise<ReturnType<T>> {
   return async (...args: Parameters<T>) => {
     const result = await fn(...args);
-    callback();
+    if (callback) callback();
     return result;
   };
 }

--- a/packages/core-react/src/helpers/wrapWithCallback.ts
+++ b/packages/core-react/src/helpers/wrapWithCallback.ts
@@ -1,0 +1,14 @@
+// Utility to wrap a function and call a callback after the function call
+export function wrapWithCallback<
+  T extends (...args: any[]) => any,
+  C extends (...args: any[]) => void,
+>(
+  fn: T,
+  callback: C,
+): (...args: Parameters<T>) => ReturnType<T> | Promise<ReturnType<T>> {
+  return async (...args: Parameters<T>) => {
+    const result = await fn(...args);
+    callback();
+    return result;
+  };
+}

--- a/packages/core-react/src/hooks/useAutoConnect.ts
+++ b/packages/core-react/src/hooks/useAutoConnect.ts
@@ -4,7 +4,7 @@ import { useEagerConnect } from './useEagerConnect';
 import { checkTermsAccepted } from '../helpers/checkTermsAccepted';
 import { useReefKnotContext } from './useReefKnotContext';
 import { LS_KEY_RECONNECT_WALLET_ID } from '../constants';
-import { wrapWithCallback } from '../helpers/wrapWithCallback';
+import { withCallback } from '../helpers/withCallback';
 
 export const useAutoConnect = (autoConnectEnabled: boolean) => {
   const { storage } = useConfig();
@@ -47,9 +47,10 @@ export const useAutoConnect = (autoConnectEnabled: boolean) => {
           // Without the delay, this code can be called from a browser's cache faster than wallet extension code
           await new Promise((resolve) => setTimeout(resolve, 100));
 
-          const reconnectWithCallback = onReconnect
-            ? wrapWithCallback(reconnectAsync, onReconnect)
-            : reconnectAsync;
+          const reconnectWithCallback = withCallback(
+            reconnectAsync,
+            onReconnect,
+          );
 
           await reconnectWithCallback({ connectors: [createConnectorFn] });
         }

--- a/packages/core-react/src/hooks/useAutoConnect.ts
+++ b/packages/core-react/src/hooks/useAutoConnect.ts
@@ -4,13 +4,14 @@ import { useEagerConnect } from './useEagerConnect';
 import { checkTermsAccepted } from '../helpers/checkTermsAccepted';
 import { useReefKnotContext } from './useReefKnotContext';
 import { LS_KEY_RECONNECT_WALLET_ID } from '../constants';
+import { wrapWithCallback } from '../helpers/wrapWithCallback';
 
 export const useAutoConnect = (autoConnectEnabled: boolean) => {
   const { storage } = useConfig();
   const { reconnectAsync } = useReconnect();
   const { isConnected } = useAccount();
   const { eagerConnect } = useEagerConnect();
-  const { walletDataList } = useReefKnotContext();
+  const { walletDataList, onReconnect } = useReefKnotContext();
 
   useEffect(() => {
     const tryReconnect = async () => {
@@ -46,7 +47,11 @@ export const useAutoConnect = (autoConnectEnabled: boolean) => {
           // Without the delay, this code can be called from a browser's cache faster than wallet extension code
           await new Promise((resolve) => setTimeout(resolve, 100));
 
-          await reconnectAsync({ connectors: [createConnectorFn] });
+          const reconnectWithCallback = onReconnect
+            ? wrapWithCallback(reconnectAsync, onReconnect)
+            : reconnectAsync;
+
+          await reconnectWithCallback({ connectors: [createConnectorFn] });
         }
       }
     };

--- a/packages/core-react/src/hooks/useEagerConnect.ts
+++ b/packages/core-react/src/hooks/useEagerConnect.ts
@@ -65,15 +65,24 @@ export const connectEagerly = async (
 export const useEagerConnect = () => {
   const config = useConfig();
   const { openModalAsync } = useReefKnotModal();
-  const { walletDataList } = useReefKnotContext();
+  const { walletDataList, onAutoConnect } = useReefKnotContext();
 
-  const eagerConnect = useCallback(() => {
+  const eagerConnect = useCallback(async () => {
     const autoConnectOnlyAdapters = walletDataList.filter(
       ({ autoConnectOnly }) => autoConnectOnly,
     );
 
-    return connectEagerly(config, autoConnectOnlyAdapters, openModalAsync);
-  }, [openModalAsync, walletDataList, config]);
+    const connectionResult = await connectEagerly(
+      config,
+      autoConnectOnlyAdapters,
+      openModalAsync,
+    );
+    if (connectionResult && onAutoConnect) {
+      onAutoConnect();
+    }
+
+    return connectionResult;
+  }, [openModalAsync, walletDataList, config, onAutoConnect]);
 
   return { eagerConnect };
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from './walletAdapter';
 export * from './reef-knot-wallets-modal';
+export * from './reef-knot-config';
 export * from './wallet-connect-button';

--- a/packages/types/src/reef-knot-config.ts
+++ b/packages/types/src/reef-knot-config.ts
@@ -1,0 +1,15 @@
+import { WalletAdapterData } from './walletAdapter';
+
+export type ReefKnotProviderConfig = {
+  autoConnect: boolean;
+  walletDataList: WalletAdapterData[];
+  onAutoConnect?: () => void;
+  onReconnect?: () => void;
+};
+
+export type ReefKnotContextValue = ReefKnotProviderConfig & {
+  loadingWalletId: string | null;
+  setLoadingWalletId: React.Dispatch<React.SetStateAction<string | null>>;
+};
+
+export type ReefKnotConfig = Omit<ReefKnotProviderConfig, 'walletDataList'>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./packages/tsconfig/react-library.json",
+  "include": ["packages/*"],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "./packages/tsconfig/react-library.json",
-  "include": ["packages/*"],
+  "include": ["packages/**/*"],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
### onAutoConnect, onReconnect:

Adds ability to pass onAutoConnect and onReconnect callbacks to the reef-knot config.

* [`packages/core-react/src/hooks/useAutoConnect.ts`](diffhunk://#diff-b64608f5936b81a1b3b9592acaaf302e80a735c8b2c94c5e0d86c02f3e21e1eaR7-R14): Imported `wrapWithCallback` and used it to wrap `reconnectAsync` with `onReconnect` callback if provided.
* [`packages/core-react/src/hooks/useEagerConnect.ts`](diffhunk://#diff-257e1cadcb8217d37d240b832fe2da4b2d4e2144aa007d4b32ff30f29ec7a352L68-R85): Updated `eagerConnect` to call `onAutoConnect` callback if provided after a successful connection.

### Utility Functions:

* [`packages/core-react/src/helpers/wrapWithCallback.ts`](diffhunk://#diff-91e4f36c0a052bb22f09e814a24b7ca30f3e8fd359ca73e9bc3596733b2dce98R1-R14): Added a utility function `wrapWithCallback` to wrap a function and call a callback after the function call.

### Demo App:

* [`apps/demo-react/utils/metrics.ts`](diffhunk://#diff-2400cbc0fdedaffa5f6db526e2a348d9e391f30d7869c7f0b1d700cc54c56fbbR27-R28): Added `onAutoConnect` and `onReconnect` to `metricProps` to log these events.

### Context Handling:

* [`packages/connect-wallet-modal/src/components/Ledger/LedgerAccountScreen.tsx`](diffhunk://#diff-f6d7e080570e8238f3cade70850f024812fb3c0bc45b0e3de68fc617cd367b44L81-R87): Updated dependencies in the effect hook to include `connectAsync`.
* [`packages/connect-wallet-modal/src/components/Ledger/LedgerContext.tsx`](diffhunk://#diff-db82a96d4b8a5a8dc624f1b4b73324e435d22b5bec84b3a53c09b108361b4d9cL117-R117): Added `loadLedgerLibs` to the dependencies of the effect hook.

### tsconfig:

* Added `tsconfig.json` to the root, because some vscode plugins rely on this file and throw an error if there isn't any.
