### PR TITLE
Fix: add missing repository fields for packages to fix provenance

### DIFF
--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -19,6 +19,11 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/lidofinance/reef-knot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/connectors/ledger-connector"
+  },
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,7 +12,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/lidofinance/reef-knot.git",
-    "directory": "packages/reef-knot"
+    "directory": "packages/types"
   },
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"

--- a/packages/wallets/ambire/package.json
+++ b/packages/wallets/ambire/package.json
@@ -19,6 +19,11 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/lidofinance/reef-knot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/ambire"
+  },
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },

--- a/packages/wallets/binance-wallet/package.json
+++ b/packages/wallets/binance-wallet/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/binance-wallet"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/bitkeep/package.json
+++ b/packages/wallets/bitkeep/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/bitkeep"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/brave/package.json
+++ b/packages/wallets/brave/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/brave"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/browserExtension/package.json
+++ b/packages/wallets/browserExtension/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/browserExtension"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/coin98/package.json
+++ b/packages/wallets/coin98/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/coin98"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/coinbase-smart-wallet/package.json
+++ b/packages/wallets/coinbase-smart-wallet/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/coinbase-smart-wallet"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/coinbase/package.json
+++ b/packages/wallets/coinbase/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/coinbase"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/ctrl/package.json
+++ b/packages/wallets/ctrl/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/ctrl"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/dappBrowserInjected/package.json
+++ b/packages/wallets/dappBrowserInjected/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/dappBrowserInjected"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/exodus/package.json
+++ b/packages/wallets/exodus/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/exodus"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/imtoken/package.json
+++ b/packages/wallets/imtoken/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/imtoken"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/ledger-hid/package.json
+++ b/packages/wallets/ledger-hid/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/ledger-hid"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/ledger-live/package.json
+++ b/packages/wallets/ledger-live/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/ledger-live"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/metamask/package.json
+++ b/packages/wallets/metamask/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/metamask"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/okx/package.json
+++ b/packages/wallets/okx/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/okx"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/phantom/package.json
+++ b/packages/wallets/phantom/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/phantom"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/safe/package.json
+++ b/packages/wallets/safe/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/safe"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/trust/package.json
+++ b/packages/wallets/trust/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/trust"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/walletconnect/package.json
+++ b/packages/wallets/walletconnect/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/walletconnect"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/packages/wallets/xdefi/package.json
+++ b/packages/wallets/xdefi/package.json
@@ -22,6 +22,11 @@
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/xdefi"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/turbo/generators/wallet/templates/package.json.hbs
+++ b/turbo/generators/wallet/templates/package.json.hbs
@@ -19,6 +19,11 @@
   ],
   "license": "MIT",
   "homepage": "https://github.com/lidofinance/reef-knot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lidofinance/reef-knot.git",
+    "directory": "packages/wallets/{{kebabCase walletId}}"
+  },
   "bugs": {
     "url": "https://github.com/lidofinance/reef-knot/issues"
   },


### PR DESCRIPTION
The PR should fix this error during npm publish with provenance:


> 'npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@reef-knot%2fledger-connector - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/lidofinance/reef-knot" from provenance\n'

