### PR TITLE
Update allowed domain for safe connector

### DIFF
--- a/packages/wallets/safe/src/index.ts
+++ b/packages/wallets/safe/src/index.ts
@@ -13,7 +13,7 @@ const getSafeConnector = ({ allowedDomains = [] }: GetSafeConnectorArgs) =>
   safe({
     allowedDomains: [
       /app.safe.global$/,
-      /holesky-safe.protofire.io$/,
+      /app.safe.protofire.io$/,
       ...allowedDomains,
     ],
     debug: false,


### PR DESCRIPTION
Holesky Safe is going to sunset and, as part of migration to Hoodi, it is required to change allowed domain for safe connector.