### PR TITLE
Attempt to trigger reef-knot 7.4.0 release

### DIFF
--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### Fixes
 
-- Update allowed domain for safe connector
-- ConnectMetaMask – use connectWithLoading for improved connection handling
+- Update allowed domain for safe connector;
+- ConnectMetaMask – use connectWithLoading for improved connection handling;
 
 ## 7.3.0
 


### PR DESCRIPTION
semantic-release wants to release reef-knot 7.3.1, however it would be more correct to release 7.4.0:
https://github.com/lidofinance/reef-knot/actions/runs/15588661108
I assume, that it happens because no files were changed in the root reef-knot package under `feat:` commit.
Trying to workaround this.