### PR TITLE
Update Bitget logo

### DIFF
--- a/packages/wallets/bitkeep/src/icons/bitget.svg
+++ b/packages/wallets/bitkeep/src/icons/bitget.svg
@@ -1,43 +1,6 @@
-<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_1899_48)">
-<rect width="256" height="256" rx="20" fill="#54FFF5"/>
-<g filter="url(#filter0_f_1899_48)">
-<path d="M13.4807 198.605C-29.3275 319.043 199.662 285.027 319.507 252.964C442.165 212.259 357.386 32.8269 269.415 28.8558C181.443 24.8847 280.322 111.824 205.595 136.656C130.868 161.487 66.9908 48.0583 13.4807 198.605Z" fill="white"/>
-</g>
-<g filter="url(#filter1_f_1899_48)">
-<path d="M85.5118 -45.8225C63.0562 -107.176 -16.9189 -23.9953 -54.0995 25.2643C-89.5652 78.8479 3.00937 125.152 39.3208 100.037C75.6323 74.9227 7.77448 70.0363 29.3708 37.3785C50.9671 4.72076 113.581 30.8695 85.5118 -45.8225Z" fill="#00FFF0" fill-opacity="0.67"/>
-</g>
-<g filter="url(#filter2_f_1899_48)">
-<path d="M96.4797 225.424C65.8504 122.363 -66.0817 176.637 -128.219 216.657C-187.99 264.042 -46.0709 400.348 12.8726 393.376C71.8162 386.403 -34.4116 327.065 1.98714 298.17C38.3859 269.276 134.766 354.249 96.4797 225.424Z" fill="#9D81FF"/>
-</g>
-<g filter="url(#filter3_f_1899_48)">
-<path d="M282.12 -107.353C216.047 -186.031 121.463 -120.97 82.4295 -78.6047C48.2738 -30.6446 224.275 57.2312 273.121 42.1714C321.968 27.1115 206.512 -4.05038 227.297 -33.2879C248.082 -62.5255 364.712 -9.00566 282.12 -107.353Z" fill="#4D94FF"/>
-</g>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M93.1892 152.836H136.674L87.2087 103.051L137.31 53.2663L150.955 40H105.819L48.336 97.7773C45.4351 100.689 45.4499 105.402 48.3658 108.299L93.1892 152.836ZM119.33 103.168H118.995L119.326 103.164L119.33 103.168ZM119.33 103.168L168.791 152.949L118.69 202.734L105.045 216H150.181L207.664 158.226C210.565 155.314 210.55 150.602 207.634 147.705L162.811 103.168H119.33Z" fill="black"/>
-</g>
-<defs>
-<filter id="filter0_f_1899_48" x="-90.241" y="-69.7369" width="569.558" height="451.431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="49.2308" result="effect1_foregroundBlur_1899_48"/>
-</filter>
-<filter id="filter1_f_1899_48" x="-160.511" y="-165.987" width="351.596" height="371.507" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="49.2308" result="effect1_foregroundBlur_1899_48"/>
-</filter>
-<filter id="filter2_f_1899_48" x="-241.077" y="67.642" width="444.851" height="424.452" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="49.2308" result="effect1_foregroundBlur_1899_48"/>
-</filter>
-<filter id="filter3_f_1899_48" x="-20.3968" y="-242.758" width="430.191" height="385.105" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-<feFlood flood-opacity="0" result="BackgroundImageFix"/>
-<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="49.2308" result="effect1_foregroundBlur_1899_48"/>
-</filter>
-<clipPath id="clip0_1899_48">
-<rect width="256" height="256" rx="20" fill="white"/>
-</clipPath>
-</defs>
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="36" height="36" rx="18" fill="#001F29" />
+  <path
+    d="M15.465 6.72917C14.1765 6.72852 12.8903 6.72786 11.5973 6.72984C10.8155 6.72984 10.5223 7.71134 11.1038 8.29272L19.9053 17.0943C20.1799 17.3455 20.3512 17.6186 20.3575 17.9785C20.3512 18.3385 20.1799 18.6115 19.9053 18.8628L11.1038 27.6643C10.5223 28.2457 10.8155 29.2272 11.5973 29.2272C12.8903 29.2292 14.1765 29.2285 15.465 29.2279C16.1101 29.2275 16.7557 29.2272 17.403 29.2272C18.2499 29.2272 18.7537 28.7748 19.2061 28.3224L27.1439 20.3845C27.7774 19.751 28.3442 18.9099 28.3365 17.9785C28.3442 17.0472 27.7774 16.206 27.1439 15.5725L19.2061 7.63467C18.7537 7.18226 18.2499 6.72984 17.403 6.72984C16.7557 6.72984 16.1101 6.7295 15.465 6.72917Z"
+    fill="#00F0FF" />
 </svg>


### PR DESCRIPTION
Use the new bitget logo, see https://web3.bitget.com/en/docs/resource/

<img width="181" height="74" alt="image" src="https://github.com/user-attachments/assets/450cef11-14ae-4088-8fc8-a0267cccd0ec" />
