### PR TITLE
Fix broken by picomatch update build – update rpt2 to v0.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rollup": "3.29.5",
     "rollup-plugin-delete": "2.0.0",
     "rollup-plugin-svg-import": "1.6.0",
-    "rollup-plugin-typescript2": "0.34.1",
+    "rollup-plugin-typescript2": "0.37.0",
     "tslib": "2.8.1",
     "turbo": "^2.7.5",
     "typescript": "~5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17353,7 +17353,7 @@ __metadata:
     rollup: 3.29.5
     rollup-plugin-delete: 2.0.0
     rollup-plugin-svg-import: 1.6.0
-    rollup-plugin-typescript2: 0.34.1
+    rollup-plugin-typescript2: 0.37.0
     tslib: 2.8.1
     turbo: ^2.7.5
     typescript: ~5.7
@@ -17673,19 +17673,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-typescript2@npm:0.34.1":
-  version: 0.34.1
-  resolution: "rollup-plugin-typescript2@npm:0.34.1"
+"rollup-plugin-typescript2@npm:0.37.0":
+  version: 0.37.0
+  resolution: "rollup-plugin-typescript2@npm:0.37.0"
   dependencies:
-    "@rollup/pluginutils": "npm:^4.1.2"
-    find-cache-dir: "npm:^3.3.2"
-    fs-extra: "npm:^10.0.0"
-    semver: "npm:^7.3.7"
-    tslib: "npm:^2.4.0"
+    "@rollup/pluginutils": ^4.1.2
+    find-cache-dir: ^3.3.2
+    fs-extra: ^10.0.0
+    semver: ^7.5.4
+    tslib: ^2.6.2
   peerDependencies:
     rollup: ">=1.26.3"
     typescript: ">=2.4.0"
-  checksum: 107e66b9ab1aaf4b237564e500ea9de9f2d3f0a81be5139dc753fc76bbf00a1a2230eb1ec59145d2dfc4c4da9be8211f1f3e1370007efe1e24ce45a00905e558
+  checksum: 650a8a5fe821eb9911aa74156df648bff3d5767fb3d9ff323f1ac1b42bbc576615600996715372274eb1fa3c951c359b7b575dd116aadccd0720e757cba56360
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/lidofinance/reef-knot/pull/289 broke the build

```
The chain:

rollup-plugin-typescript2
  → @rollup/pluginutils (createFilter)
    → picomatch

rpt2 uses @rollup/pluginutils's createFilter to decide which files its transform() hook should handle. The default include pattern is:

['*.ts+(|x)', '**/*.ts+(|x)']

That +(|x) is an extglob — "one or more of: empty string or x" — used to match both .ts and .tsx.

What picomatch 2.3.2 broke: It changed extglob handling in a way that caused +(|x) patterns to stop matching correctly for the "empty string" branch. So *.ts+(|x) would no longer match plain .ts files — only .tsx.

The consequence:

rpt2's filter says "this .ts file doesn't match my include pattern" → returns null from transform()
Rollup moves to the next plugin: @rollup/plugin-babel
Babel receives raw TypeScript (no @babel/preset-typescript configured for wallets-helpers)
Babel's JS parser hits type WCConnector = ... → "Missing semicolon"
Rollup attributes the error to (plugin rpt2) because that's the plugin context wrapping the transform chain
```

This is fixed by rollup-plugin-typescript2 v0.37.0