### PR TITLE
fix: add noopener and noreferrer to window.open

### DIFF
--- a/packages/connect-wallet-modal/CHANGELOG.md
+++ b/packages/connect-wallet-modal/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @reef-knot/connect-wallet-modal
 
+## 8.0.1
+
+- Add noopener and noreferrer to WalletConnect redirect popup
+
 ## 8.0.0
 
 - Build using node 24, yarn 3.8.7

--- a/packages/connect-wallet-modal/src/connectButtons/ConnectWC.tsx
+++ b/packages/connect-wallet-modal/src/connectButtons/ConnectWC.tsx
@@ -68,7 +68,7 @@ export const ConnectWC: FC<ConnectWCProps> = (props: ConnectWCProps) => {
     if (WCURICondition && WCURIConnectorFn && WCURIRedirectLink) {
       // BEGIN Handle connection via redirect using WC Pairing URI (without WalletConnect QR modal)
       // Because of popup blockers, window.open must be called directly from onclick handler
-      redirectionWindow = window.open('', '_blank');
+      redirectionWindow = window.open('', '_blank', 'noopener,noreferrer');
       redirectionWindow?.document.write(getRedirectionLoadingHTML());
 
       await Promise.all([

--- a/packages/reef-knot/CHANGELOG.md
+++ b/packages/reef-knot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # reef-knot
 
+## 8.1.1
+
+- Add noopener and noreferrer to WalletConnect redirect popup
+
 ## 8.1.0
 
 - Add support for Anchorage Digital wallet


### PR DESCRIPTION
Fixes a minor security issue – adds noopener and noreferrer to WalletConnect redirect popup