### PR TITLE
Ledger connector: bugfixes and tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,35 @@
+name: Unit tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run unit tests
+        run: yarn test

--- a/packages/connectors/ledger-connector/package.json
+++ b/packages/connectors/ledger-connector/package.json
@@ -35,13 +35,17 @@
     "build": "yarn run -T tsdown",
     "dev": "yarn run -T tsdown --watch",
     "lint": "eslint --ext ts,tsx,js,mjs .",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@ledgerhq/hw-transport-mocker": "6.34.7",
     "@types/w3c-web-hid": "^1.0.7",
     "build-config": "*",
     "eslint-config-custom": "*",
+    "happy-dom": "^20.0.0",
     "viem": ">=2.50",
+    "vitest": "^3.2.4",
     "wagmi": ">=3.6"
   },
   "dependencies": {

--- a/packages/connectors/ledger-connector/src/__tests__/ssr.test.ts
+++ b/packages/connectors/ledger-connector/src/__tests__/ssr.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+//
+// Both connectors are imported by SSR frameworks (Next.js) where no window
+// exists — every helper that touches browser state must be inert there.
+import { describe, expect, it } from 'vitest';
+import {
+  clearLedgerAccount,
+  clearLedgerChainId,
+  clearLedgerDerivationPath,
+  restoreLedgerAccount,
+  restoreLedgerChainId,
+  saveLedgerAccount,
+  saveLedgerChainId,
+} from '../hid/helpers';
+import { isIframe, isLedgerLive } from '../iframe/helpers';
+
+describe('without a window (SSR)', () => {
+  it('chain id persistence is inert', () => {
+    expect(() => saveLedgerChainId(1)).not.toThrow();
+    expect(restoreLedgerChainId()).toBeUndefined();
+    expect(() => clearLedgerChainId()).not.toThrow();
+  });
+
+  it('account persistence is inert', () => {
+    expect(() =>
+      saveLedgerAccount({
+        address: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+        path: "m/44'/60'/0'/0/0",
+      }),
+    ).not.toThrow();
+    expect(restoreLedgerAccount()).toBeUndefined();
+    expect(() => clearLedgerAccount()).not.toThrow();
+  });
+
+  it('derivation path clearing is inert', () => {
+    expect(() => clearLedgerDerivationPath()).not.toThrow();
+  });
+
+  it('Ledger Live detection is negative', () => {
+    expect(isLedgerLive()).toBe(false);
+    expect(isIframe()).toBeFalsy();
+  });
+});

--- a/packages/connectors/ledger-connector/src/hid/__tests__/connector.test.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/connector.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SwitchChainError } from 'viem';
+import { mainnet, optimism } from 'viem/chains';
+import { idLedgerHid, ledgerHIDConnector } from '../connector';
+import {
+  LS_KEY_ACCOUNT,
+  LS_KEY_CHAIN_ID,
+  LS_KEY_DERIVATION_PATH,
+} from '../constants';
+import {
+  ADDRESS_A,
+  APP_CONFIG,
+  DEVICE_LOCKED,
+  getAddressExchange,
+  injectReplayer,
+  stubHid,
+} from './fixtures';
+
+const RPC_URL = 'https://rpc.test.local';
+
+const setup = () => {
+  const emitter = { emit: vi.fn() };
+  const connector = ledgerHIDConnector({
+    rpc: { [mainnet.id]: RPC_URL, [optimism.id]: RPC_URL },
+    defaultChain: mainnet,
+  })({ chains: [mainnet, optimism], emitter } as never);
+  return { connector, emitter };
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  stubHid();
+});
+
+describe('chain selection', () => {
+  it('starts on the default chain', async () => {
+    const { connector } = setup();
+    expect(connector.id).toBe(idLedgerHid);
+    await expect(connector.getChainId()).resolves.toBe(mainnet.id);
+  });
+
+  it('restores the persisted chain', async () => {
+    window.localStorage.setItem(LS_KEY_CHAIN_ID, String(optimism.id));
+    const { connector } = setup();
+    await expect(connector.getChainId()).resolves.toBe(optimism.id);
+  });
+
+  it('switches chain, persists it and notifies wagmi', async () => {
+    const { connector, emitter } = setup();
+
+    const chain = await connector.switchChain?.({ chainId: optimism.id });
+    expect(chain?.id).toBe(optimism.id);
+    expect(window.localStorage.getItem(LS_KEY_CHAIN_ID)).toBe(
+      String(optimism.id),
+    );
+    expect(emitter.emit).toHaveBeenCalledWith('change', {
+      chainId: optimism.id,
+    });
+    await expect(connector.getChainId()).resolves.toBe(optimism.id);
+  });
+
+  it('rejects switching to an unconfigured chain', async () => {
+    const { connector } = setup();
+    await expect(
+      connector.switchChain?.({ chainId: 137 }),
+    ).rejects.toBeInstanceOf(SwitchChainError);
+  });
+
+  it('caches one provider per chain', async () => {
+    const { connector } = setup();
+    const one = await connector.getProvider({ chainId: mainnet.id });
+    const two = await connector.getProvider({ chainId: optimism.id });
+    expect(one).not.toBe(two);
+    expect(one.chain.id).toBe(mainnet.id);
+    expect(two.chain.id).toBe(optimism.id);
+    await expect(connector.getProvider({ chainId: mainnet.id })).resolves.toBe(
+      one,
+    );
+  });
+});
+
+describe('connect', () => {
+  it('connects on the requested chain and persists the session', async () => {
+    const { connector } = setup();
+    const provider = await connector.getProvider({ chainId: mainnet.id });
+    injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
+
+    await expect(connector.connect({ chainId: mainnet.id })).resolves.toEqual({
+      accounts: [ADDRESS_A],
+      chainId: mainnet.id,
+    });
+    expect(window.localStorage.getItem(LS_KEY_CHAIN_ID)).toBe(
+      String(mainnet.id),
+    );
+    expect(window.localStorage.getItem(LS_KEY_ACCOUNT)).toContain(ADDRESS_A);
+    await expect(connector.isAuthorized()).resolves.toBe(true);
+  });
+
+  it('returns capability-shaped accounts when asked', async () => {
+    const { connector } = setup();
+    const provider = await connector.getProvider({ chainId: mainnet.id });
+    injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
+
+    await expect(
+      connector.connect({ chainId: mainnet.id, withCapabilities: true }),
+    ).resolves.toEqual({
+      accounts: [{ address: ADDRESS_A, capabilities: {} }],
+      chainId: mainnet.id,
+    });
+  });
+
+  it('reconnects without a chainId onto the persisted chain', async () => {
+    window.localStorage.setItem(LS_KEY_CHAIN_ID, String(optimism.id));
+    const { connector } = setup();
+    const provider = await connector.getProvider();
+    expect(provider.chain.id).toBe(optimism.id);
+    injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
+
+    await expect(connector.connect({ isReconnecting: true })).resolves.toEqual({
+      accounts: [ADDRESS_A],
+      chainId: optimism.id,
+    });
+  });
+
+  it('reverts to the persisted chain when connecting fails', async () => {
+    window.localStorage.setItem(LS_KEY_CHAIN_ID, String(optimism.id));
+    const { connector } = setup();
+    const provider = await connector.getProvider({ chainId: mainnet.id });
+    // Locked device with no persisted account: the connect fails.
+    injectReplayer(provider, DEVICE_LOCKED);
+
+    await expect(
+      connector.connect({ chainId: mainnet.id }),
+    ).rejects.toMatchObject({ name: 'LockedDeviceError' });
+    await expect(connector.getChainId()).resolves.toBe(optimism.id);
+  });
+
+  it('disconnect forgets the chain, account and derivation path', async () => {
+    const { connector } = setup();
+    const provider = await connector.getProvider({ chainId: optimism.id });
+    injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
+    await connector.connect({ chainId: optimism.id });
+    window.localStorage.setItem(LS_KEY_DERIVATION_PATH, "m/44'/60'/1'/0/0");
+
+    await connector.disconnect();
+
+    expect(window.localStorage.getItem(LS_KEY_CHAIN_ID)).toBeNull();
+    expect(window.localStorage.getItem(LS_KEY_ACCOUNT)).toBeNull();
+    expect(window.localStorage.getItem(LS_KEY_DERIVATION_PATH)).toBeNull();
+    await expect(connector.getChainId()).resolves.toBe(mainnet.id);
+  });
+});

--- a/packages/connectors/ledger-connector/src/hid/__tests__/fixtures.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/fixtures.ts
@@ -12,6 +12,7 @@ import type { LedgerHQProvider } from '../provider';
 // 'reef-knot', the legacy transaction and the typed data defined here).
 
 export const DERIVATION_PATH = "m/44'/60'/0'/0/0";
+export const DERIVATION_PATH_B = "m/44'/60'/1'/0/0";
 
 export const ADDRESS_A: Address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 export const ADDRESS_B: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
@@ -40,6 +41,10 @@ export const getAddressExchange = (address: Address) =>
   '=> e002000015058000002c8000003c800000000000000000000000\n' +
   `<= 4104${'ab'.repeat(64)}28${asciiHex(address.slice(2))}9000`;
 
+export const getAddressExchangeForPathB = (address: Address) =>
+  '=> e002000015058000002c8000003c800000010000000000000000\n' +
+  `<= 4104${'ab'.repeat(64)}28${asciiHex(address.slice(2))}9000`;
+
 export const PERSONAL_SIGN_MESSAGE = 'reef-knot';
 export const PERSONAL_SIGN =
   '=> e008000022058000002c8000003c80000000000000000000000000000009726565662d6b6e6f74\n' +
@@ -59,6 +64,45 @@ export const LEGACY_TX = {
 export const SIGN_TX =
   '=> e004000039058000002c8000003c800000000000000000000000e380843b9aca0082520894d8da6bf26964af9d7eed9e03e53415d37aa960450180018080\n' +
   `<= ${signatureResponse('25')}`;
+
+// The fixture transaction after viem fills the missing fee fields itself:
+// eth_gasPrice (1 gwei) times viem's 1.2 legacy fee multiplier.
+export const FILLED_LEGACY_TX = {
+  ...LEGACY_TX,
+  gasPrice: 1200000000n,
+} as const;
+export const SIGN_TX_FILLED =
+  '=> e004000039058000002c8000003c800000000000000000000000e3808447868c0082520894d8da6bf26964af9d7eed9e03e53415d37aa960450180018080\n' +
+  `<= ${signatureResponse('25')}`;
+
+// EIP-1559 transfer with the same to/value/nonce/gas; signed with yParity 0.
+export const TX_1559 = {
+  chainId: 1,
+  nonce: 0,
+  maxPriorityFeePerGas: 1000000000n,
+  maxFeePerGas: 2000000000n,
+  gas: 21000n,
+  to: ADDRESS_A,
+  value: 1n,
+} as const;
+export const SIGN_TX_1559 =
+  '=> e00400003e058000002c8000003c80000000000000000000000002e70180843b9aca00847735940082520894d8da6bf26964af9d7eed9e03e53415d37aa960450180c0\n' +
+  `<= ${signatureResponse('00')}`;
+
+// EIP-2930 transfer with an empty access list; signed with yParity 0.
+export const TX_2930 = {
+  chainId: 1,
+  type: 'eip2930',
+  nonce: 0,
+  gasPrice: 1000000000n,
+  gas: 21000n,
+  to: ADDRESS_A,
+  value: 1n,
+  accessList: [],
+} as const;
+export const SIGN_TX_2930 =
+  '=> e004000039058000002c8000003c80000000000000000000000001e20180843b9aca0082520894d8da6bf26964af9d7eed9e03e53415d37aa960450180c0\n' +
+  `<= ${signatureResponse('00')}`;
 
 export const TYPED_DATA = {
   domain: { name: 'ReefKnot', version: '1', chainId: 1 },
@@ -96,10 +140,39 @@ export const injectReplayer = (
   return store;
 };
 
+// As injectReplayer, but stamps a device onto each opened transport so the
+// provider's HID disconnect matching has something to compare against.
+export const injectReplayerWithDevice = (
+  provider: LedgerHQProvider,
+  device: HIDDevice,
+  ...exchanges: string[]
+) => {
+  const store = RecordStore.fromString(exchanges.join('\n'));
+  provider.transport = {
+    create: async () =>
+      Object.assign(await openTransportReplayer(store), { device }),
+  } as unknown as typeof TransportWebHID;
+  return store;
+};
+
 // enable() subscribes to HID disconnect events; happy-dom has no WebHID.
+// The returned `unplug` simulates the browser firing such an event.
 export const stubHid = () => {
+  type HidListener = (event: HIDConnectionEvent) => void;
+  const listeners = new Set<HidListener>();
   Object.defineProperty(window.navigator, 'hid', {
-    value: { addEventListener: () => {}, removeEventListener: () => {} },
+    value: {
+      addEventListener: (_type: string, listener: HidListener) =>
+        listeners.add(listener),
+      removeEventListener: (_type: string, listener: HidListener) =>
+        listeners.delete(listener),
+    },
     configurable: true,
   });
+  return {
+    unplug: (device: HIDDevice) =>
+      [...listeners].forEach((listener) =>
+        listener({ device } as HIDConnectionEvent),
+      ),
+  };
 };

--- a/packages/connectors/ledger-connector/src/hid/__tests__/fixtures.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/fixtures.ts
@@ -1,0 +1,105 @@
+import {
+  openTransportReplayer,
+  RecordStore,
+} from '@ledgerhq/hw-transport-mocker';
+import type TransportWebHID from '@ledgerhq/hw-transport-webhid';
+import type { Address } from 'viem';
+import type { LedgerHQProvider } from '../provider';
+
+// The APDU exchanges below were recorded from @ledgerhq/hw-app-eth@7.8.12
+// with @ledgerhq/hw-transport-mocker's createTransportRecorder, for the
+// exact inputs the tests replay (default derivation path, the message
+// 'reef-knot', the legacy transaction and the typed data defined here).
+
+export const DERIVATION_PATH = "m/44'/60'/0'/0/0";
+
+export const ADDRESS_A: Address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+export const ADDRESS_B: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+export const SIGNATURE_R = `0x${'11'.repeat(32)}` as const;
+export const SIGNATURE_S = `0x${'22'.repeat(32)}` as const;
+// serializeSignature output for the fixture r/s with v = 27 (0x1b).
+export const MESSAGE_SIGNATURE = `0x${'11'.repeat(32)}${'22'.repeat(32)}1b`;
+
+// [v][r][s] + APDU status 9000.
+const signatureResponse = (v: string) =>
+  `${v}${'11'.repeat(32)}${'22'.repeat(32)}9000`;
+
+const asciiHex = (value: string) =>
+  [...value]
+    .map((char) => char.charCodeAt(0).toString(16).padStart(2, '0'))
+    .join('');
+
+export const APP_CONFIG = '=> e006000000\n<= 010109009000';
+
+// getAppConfiguration answered with 0x5515 (LOCKED_DEVICE).
+export const DEVICE_LOCKED = '=> e006000000\n<= 5515';
+
+// getAddress: [pubkey_len][pubkey][address_len][ascii address] 9000.
+export const getAddressExchange = (address: Address) =>
+  '=> e002000015058000002c8000003c800000000000000000000000\n' +
+  `<= 4104${'ab'.repeat(64)}28${asciiHex(address.slice(2))}9000`;
+
+export const PERSONAL_SIGN_MESSAGE = 'reef-knot';
+export const PERSONAL_SIGN =
+  '=> e008000022058000002c8000003c80000000000000000000000000000009726565662d6b6e6f74\n' +
+  `<= ${signatureResponse('1b')}`;
+
+// Legacy transfer: chainId 1, nonce 0, gasPrice 1 gwei, gas 21000,
+// to ADDRESS_A, value 1 wei. Signed with v = 0x25 (EIP-155 parity 0).
+export const LEGACY_TX = {
+  type: 'legacy',
+  chainId: 1,
+  nonce: 0,
+  gasPrice: 1000000000n,
+  gas: 21000n,
+  to: ADDRESS_A,
+  value: 1n,
+} as const;
+export const SIGN_TX =
+  '=> e004000039058000002c8000003c800000000000000000000000e380843b9aca0082520894d8da6bf26964af9d7eed9e03e53415d37aa960450180018080\n' +
+  `<= ${signatureResponse('25')}`;
+
+export const TYPED_DATA = {
+  domain: { name: 'ReefKnot', version: '1', chainId: 1 },
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+    ],
+    Mail: [{ name: 'contents', type: 'string' }],
+  },
+  primaryType: 'Mail',
+  message: { contents: 'hi' },
+};
+
+// The device rejects the structured EIP-712 flow (a Nano S without full
+// EIP-712 support): the version probe gets INS_NOT_SUPPORTED (0x6d00)…
+export const EIP712_REJECT = '=> b001000000\n<= 6d00';
+// …and the account falls back to signing the domain and message hashes.
+export const EIP712_HASHED =
+  '=> e00c000055058000002c8000003c800000000000000000000000239f83f0e5cffb0066b29194d820885963cf4631edc247a93465edf245fe2a743ae9302329ea4532e9dfd49237157e053215d5e0fa97711ed9ab4e607ae24b1c\n' +
+  `<= ${signatureResponse('1b')}`;
+
+// Points the provider's transport at a replayer over the given exchanges.
+// Each withEthApp call opens a fresh transport; all of them consume the
+// same store sequentially, exactly like consecutive real device sessions.
+export const injectReplayer = (
+  provider: LedgerHQProvider,
+  ...exchanges: string[]
+) => {
+  const store = RecordStore.fromString(exchanges.join('\n'));
+  provider.transport = {
+    create: () => openTransportReplayer(store),
+  } as unknown as typeof TransportWebHID;
+  return store;
+};
+
+// enable() subscribes to HID disconnect events; happy-dom has no WebHID.
+export const stubHid = () => {
+  Object.defineProperty(window.navigator, 'hid', {
+    value: { addEventListener: () => {}, removeEventListener: () => {} },
+    configurable: true,
+  });
+};

--- a/packages/connectors/ledger-connector/src/hid/__tests__/helpers.test.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/helpers.test.ts
@@ -72,11 +72,13 @@ describe('device errors', () => {
     expect(isLockedDeviceError(undefined)).toBe(false);
   });
 
-  it('rewrites known transport status messages', () => {
-    const error = Object.assign(new Error('raw'), {
-      statusText: 'CONDITIONS_OF_USE_NOT_SATISFIED',
-    });
-    expect(() => checkError(error)).toThrow('User rejected the request');
+  it.each([
+    ['CONDITIONS_OF_USE_NOT_SATISFIED', 'User rejected the request'],
+    ['INS_NOT_SUPPORTED', 'Device is not supported'],
+    ['UNKNOWN_ERROR', 'Unknown error. Make sure the device is connected'],
+  ])('rewrites the %s transport status message', (statusText, message) => {
+    const error = Object.assign(new Error('raw'), { statusText });
+    expect(() => checkError(error)).toThrow(message);
   });
 
   it('rethrows unknown errors untouched', () => {

--- a/packages/connectors/ledger-connector/src/hid/__tests__/helpers.test.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/helpers.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkError,
+  clearLedgerAccount,
+  clearLedgerChainId,
+  isLockedDeviceError,
+  restoreLedgerAccount,
+  restoreLedgerChainId,
+  saveLedgerAccount,
+  saveLedgerChainId,
+} from '../helpers';
+import { LS_KEY_ACCOUNT, LS_KEY_CHAIN_ID } from '../constants';
+import { ADDRESS_A, DERIVATION_PATH } from './fixtures';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('chain id persistence', () => {
+  it('round-trips a chain id', () => {
+    saveLedgerChainId(10);
+    expect(restoreLedgerChainId()).toBe(10);
+    clearLedgerChainId();
+    expect(restoreLedgerChainId()).toBeUndefined();
+  });
+
+  it('rejects a malformed stored value', () => {
+    window.localStorage.setItem(LS_KEY_CHAIN_ID, 'not-a-number');
+    expect(restoreLedgerChainId()).toBeUndefined();
+    window.localStorage.setItem(LS_KEY_CHAIN_ID, '-5');
+    expect(restoreLedgerChainId()).toBeUndefined();
+  });
+});
+
+describe('account persistence', () => {
+  it('round-trips an account', () => {
+    saveLedgerAccount({ address: ADDRESS_A, path: DERIVATION_PATH });
+    expect(restoreLedgerAccount()).toEqual({
+      address: ADDRESS_A,
+      path: DERIVATION_PATH,
+    });
+    clearLedgerAccount();
+    expect(restoreLedgerAccount()).toBeUndefined();
+  });
+
+  it('rejects malformed JSON', () => {
+    window.localStorage.setItem(LS_KEY_ACCOUNT, '{oops');
+    expect(restoreLedgerAccount()).toBeUndefined();
+  });
+
+  it('rejects a record without a valid address', () => {
+    window.localStorage.setItem(
+      LS_KEY_ACCOUNT,
+      JSON.stringify({ address: '0x123', path: DERIVATION_PATH }),
+    );
+    expect(restoreLedgerAccount()).toBeUndefined();
+  });
+
+  it('rejects a record without a path', () => {
+    window.localStorage.setItem(
+      LS_KEY_ACCOUNT,
+      JSON.stringify({ address: ADDRESS_A }),
+    );
+    expect(restoreLedgerAccount()).toBeUndefined();
+  });
+});
+
+describe('device errors', () => {
+  it('recognizes a locked-device error by name', () => {
+    expect(isLockedDeviceError({ name: 'LockedDeviceError' })).toBe(true);
+    expect(isLockedDeviceError(new Error('other'))).toBe(false);
+    expect(isLockedDeviceError(undefined)).toBe(false);
+  });
+
+  it('rewrites known transport status messages', () => {
+    const error = Object.assign(new Error('raw'), {
+      statusText: 'CONDITIONS_OF_USE_NOT_SATISFIED',
+    });
+    expect(() => checkError(error)).toThrow('User rejected the request');
+  });
+
+  it('rethrows unknown errors untouched', () => {
+    const error = new Error('untouched');
+    expect(() => checkError(error)).toThrow('untouched');
+  });
+});

--- a/packages/connectors/ledger-connector/src/hid/__tests__/provider.test.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/provider.test.ts
@@ -1,0 +1,400 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { serializeTransaction, stringToHex } from 'viem';
+import { mainnet, optimism } from 'viem/chains';
+import { LedgerHQProvider } from '../provider';
+import { LS_KEY_ACCOUNT } from '../constants';
+import {
+  ADDRESS_A,
+  ADDRESS_B,
+  APP_CONFIG,
+  DERIVATION_PATH,
+  DEVICE_LOCKED,
+  EIP712_HASHED,
+  EIP712_REJECT,
+  getAddressExchange,
+  injectReplayer,
+  LEGACY_TX,
+  MESSAGE_SIGNATURE,
+  PERSONAL_SIGN,
+  PERSONAL_SIGN_MESSAGE,
+  SIGN_TX,
+  SIGNATURE_R,
+  SIGNATURE_S,
+  stubHid,
+  TYPED_DATA,
+} from './fixtures';
+
+const RPC_URL = 'https://rpc.test.local';
+
+const createProvider = () =>
+  new LedgerHQProvider({
+    chain: mainnet,
+    rpcUrl: RPC_URL,
+    supportedChainIds: [mainnet.id, optimism.id],
+  });
+
+type RpcHandlers = Record<string, (params: unknown[]) => unknown>;
+type RpcRequest = { id: number; method: string; params: unknown[] };
+
+// Serves the provider's http transports (batch mode wraps requests in
+// arrays). An unstubbed method fails the request loudly.
+const stubRpc = (handlers: RpcHandlers) => {
+  const calls: { method: string; params: unknown[] }[] = [];
+  const respond = (request: RpcRequest) => {
+    calls.push({ method: request.method, params: request.params });
+    const handler = handlers[request.method];
+    if (!handler)
+      return {
+        jsonrpc: '2.0',
+        id: request.id,
+        error: { code: -32601, message: `no RPC stub for ${request.method}` },
+      };
+    return { jsonrpc: '2.0', id: request.id, result: handler(request.params) };
+  };
+  const fetchMock = vi.fn((_url: unknown, init?: { body?: string }) => {
+    const body = JSON.parse(init?.body ?? '{}') as RpcRequest | RpcRequest[];
+    const payload = Array.isArray(body) ? body.map(respond) : respond(body);
+    return Promise.resolve(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return { calls, fetchMock };
+};
+
+const persistAccount = (address = ADDRESS_A, path = DERIVATION_PATH) =>
+  window.localStorage.setItem(
+    LS_KEY_ACCOUNT,
+    JSON.stringify({ address, path }),
+  );
+
+beforeEach(() => {
+  window.localStorage.clear();
+  stubHid();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('request routing', () => {
+  it('answers eth_chainId locally', async () => {
+    const provider = createProvider();
+    await expect(provider.request({ method: 'eth_chainId' })).resolves.toBe(
+      '0x1',
+    );
+  });
+
+  it('answers wallet_getCapabilities for all supported chains by default', async () => {
+    const provider = createProvider();
+    await expect(
+      provider.request({
+        method: 'wallet_getCapabilities',
+        params: [ADDRESS_A],
+      }),
+    ).resolves.toEqual({ '0x1': {}, '0xa': {} });
+  });
+
+  it('omits unsupported chains from wallet_getCapabilities', async () => {
+    const provider = createProvider();
+    await expect(
+      provider.request({
+        method: 'wallet_getCapabilities',
+        params: [ADDRESS_A, ['0xa', '0x89']],
+      }),
+    ).resolves.toEqual({ '0xa': {} });
+  });
+
+  it('ignores malformed chain ids in wallet_getCapabilities', async () => {
+    const provider = createProvider();
+    await expect(
+      provider.request({
+        method: 'wallet_getCapabilities',
+        params: [ADDRESS_A, ['nonsense', 42]],
+      }),
+    ).resolves.toEqual({});
+  });
+
+  it.each([
+    'wallet_sendCalls',
+    'wallet_watchAsset',
+    'wallet_addEthereumChain',
+    'wallet_requestPermissions',
+    'eth_signTransaction',
+    'eth_signTypedData',
+    'eth_signTypedData_v1',
+    'eth_signTypedData_v3',
+    'eth_decrypt',
+    'eth_getEncryptionPublicKey',
+    'personal_ecRecover',
+  ])('fails %s closed without touching the RPC node', async (method) => {
+    const { fetchMock } = stubRpc({});
+    const provider = createProvider();
+    await expect(provider.request({ method })).rejects.toMatchObject({
+      name: 'MethodNotSupportedRpcError',
+      code: -32004,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes node methods through to the RPC endpoint', async () => {
+    const { calls } = stubRpc({ eth_blockNumber: () => '0x10' });
+    const provider = createProvider();
+    await expect(provider.request({ method: 'eth_blockNumber' })).resolves.toBe(
+      '0x10',
+    );
+    expect(calls).toEqual([{ method: 'eth_blockNumber', params: [] }]);
+  });
+});
+
+describe('accounts', () => {
+  it('enables by reading the address from the device and persists it', async () => {
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+    );
+
+    await expect(provider.enable()).resolves.toBe(ADDRESS_A);
+    expect(
+      JSON.parse(window.localStorage.getItem(LS_KEY_ACCOUNT) ?? ''),
+    ).toEqual({ address: ADDRESS_A, path: DERIVATION_PATH });
+    store.ensureQueueEmpty();
+  });
+
+  it('answers eth_accounts and eth_requestAccounts with the device address', async () => {
+    const provider = createProvider();
+    injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toEqual(
+      [ADDRESS_A],
+    );
+    // The account is cached: no further device exchanges are recorded.
+    await expect(
+      provider.request({ method: 'eth_requestAccounts' }),
+    ).resolves.toEqual([ADDRESS_A]);
+  });
+});
+
+describe('signing', () => {
+  it('signs personal_sign messages on the device', async () => {
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      // Session 1: account read. Session 2: signing.
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      PERSONAL_SIGN,
+    );
+
+    await expect(
+      provider.request({
+        method: 'personal_sign',
+        params: [stringToHex(PERSONAL_SIGN_MESSAGE), ADDRESS_A],
+      }),
+    ).resolves.toBe(MESSAGE_SIGNATURE);
+    store.ensureQueueEmpty();
+  });
+
+  it('signs eth_sign messages on the device', async () => {
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      PERSONAL_SIGN,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_sign',
+        params: [ADDRESS_A, stringToHex(PERSONAL_SIGN_MESSAGE)],
+      }),
+    ).resolves.toBe(MESSAGE_SIGNATURE);
+    store.ensureQueueEmpty();
+  });
+
+  it('rejects non-hex personal_sign messages', async () => {
+    const provider = createProvider();
+    await expect(
+      provider.request({ method: 'personal_sign', params: ['hello'] }),
+    ).rejects.toThrow('personal_sign message must be a hex string');
+  });
+
+  it('falls back to hashed EIP-712 signing on devices without full support', async () => {
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      // The signing session: the structured flow is rejected with
+      // INS_NOT_SUPPORTED and the hashed flow signs instead.
+      APP_CONFIG,
+      EIP712_REJECT,
+      EIP712_HASHED,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [ADDRESS_A, JSON.stringify(TYPED_DATA)],
+      }),
+    ).resolves.toBe(MESSAGE_SIGNATURE);
+    store.ensureQueueEmpty();
+  });
+
+  it('signs and broadcasts eth_sendTransaction', async () => {
+    const { calls } = stubRpc({
+      eth_chainId: () => '0x1',
+      eth_sendRawTransaction: () => '0xtxhash',
+    });
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      SIGN_TX,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: ADDRESS_A,
+            to: LEGACY_TX.to,
+            value: '0x1',
+            gas: '0x5208',
+            gasPrice: '0x3b9aca00',
+            nonce: '0x0',
+            type: '0x0',
+          },
+        ],
+      }),
+    ).resolves.toBe('0xtxhash');
+
+    // The broadcast payload is the fixture transaction serialized with the
+    // device signature (v = 0x25 → 37).
+    const expectedRaw = serializeTransaction(LEGACY_TX, {
+      r: SIGNATURE_R,
+      s: SIGNATURE_S,
+      v: 37n,
+    });
+    expect(calls).toContainEqual({
+      method: 'eth_sendRawTransaction',
+      params: [expectedRaw],
+    });
+    store.ensureQueueEmpty();
+  });
+
+  it('rejects eth_sendTransaction from a foreign address', async () => {
+    const provider = createProvider();
+    injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
+
+    await expect(
+      provider.request({
+        method: 'eth_sendTransaction',
+        params: [{ from: ADDRESS_B, to: ADDRESS_A, value: '0x1' }],
+      }),
+    ).rejects.toThrow('from address mismatch');
+  });
+});
+
+describe('locked device', () => {
+  it('propagates the lock error when no account was persisted', async () => {
+    const provider = createProvider();
+    injectReplayer(provider, DEVICE_LOCKED);
+
+    await expect(
+      provider.request({ method: 'eth_accounts' }),
+    ).rejects.toMatchObject({ name: 'LockedDeviceError' });
+  });
+
+  it('falls back to the persisted account while the device is locked', async () => {
+    persistAccount();
+    const provider = createProvider();
+    const store = injectReplayer(provider, DEVICE_LOCKED);
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toEqual(
+      [ADDRESS_A],
+    );
+    store.ensureQueueEmpty();
+  });
+
+  it('ignores the persisted account when the derivation path differs', async () => {
+    persistAccount(ADDRESS_A, "m/44'/60'/1'/0/0");
+    const provider = createProvider();
+    injectReplayer(provider, DEVICE_LOCKED);
+
+    await expect(
+      provider.request({ method: 'eth_accounts' }),
+    ).rejects.toMatchObject({ name: 'LockedDeviceError' });
+  });
+
+  it('verifies a restored account against the device once before signing', async () => {
+    persistAccount();
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      // Session 1: locked account read (fallback to the persisted address).
+      DEVICE_LOCKED,
+      // Session 2 (unlocked): the address is verified, then the message
+      // is signed — in the same device session.
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      PERSONAL_SIGN,
+      // Session 3: already verified — signs without re-reading the address.
+      APP_CONFIG,
+      PERSONAL_SIGN,
+    );
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toEqual(
+      [ADDRESS_A],
+    );
+
+    const sign = () =>
+      provider.request({
+        method: 'personal_sign',
+        params: [stringToHex(PERSONAL_SIGN_MESSAGE), ADDRESS_A],
+      });
+    await expect(sign()).resolves.toBe(MESSAGE_SIGNATURE);
+    await expect(sign()).resolves.toBe(MESSAGE_SIGNATURE);
+    store.ensureQueueEmpty();
+  });
+
+  it('fails closed when the unlocked device holds a different account', async () => {
+    persistAccount();
+    const provider = createProvider();
+    const onDisconnect = vi.fn();
+    provider.on('disconnect', onDisconnect);
+    const store = injectReplayer(
+      provider,
+      DEVICE_LOCKED,
+      // The unlocked device reports a different address at the same path:
+      // nothing must be signed.
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_B),
+    );
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toEqual(
+      [ADDRESS_A],
+    );
+    await expect(
+      provider.request({
+        method: 'personal_sign',
+        params: [stringToHex(PERSONAL_SIGN_MESSAGE), ADDRESS_A],
+      }),
+    ).rejects.toThrow('The connected account does not match the device');
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(LS_KEY_ACCOUNT)).toBeNull();
+    store.ensureQueueEmpty();
+  });
+});

--- a/packages/connectors/ledger-connector/src/hid/__tests__/provider.test.ts
+++ b/packages/connectors/ledger-connector/src/hid/__tests__/provider.test.ts
@@ -2,25 +2,34 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { serializeTransaction, stringToHex } from 'viem';
 import { mainnet, optimism } from 'viem/chains';
 import { LedgerHQProvider } from '../provider';
-import { LS_KEY_ACCOUNT } from '../constants';
+import { LS_KEY_ACCOUNT, LS_KEY_DERIVATION_PATH } from '../constants';
 import {
   ADDRESS_A,
   ADDRESS_B,
   APP_CONFIG,
   DERIVATION_PATH,
+  DERIVATION_PATH_B,
   DEVICE_LOCKED,
   EIP712_HASHED,
   EIP712_REJECT,
   getAddressExchange,
+  FILLED_LEGACY_TX,
+  getAddressExchangeForPathB,
   injectReplayer,
+  injectReplayerWithDevice,
   LEGACY_TX,
   MESSAGE_SIGNATURE,
   PERSONAL_SIGN,
   PERSONAL_SIGN_MESSAGE,
   SIGN_TX,
+  SIGN_TX_1559,
+  SIGN_TX_2930,
+  SIGN_TX_FILLED,
   SIGNATURE_R,
   SIGNATURE_S,
   stubHid,
+  TX_1559,
+  TX_2930,
   TYPED_DATA,
 } from './fixtures';
 
@@ -294,6 +303,194 @@ describe('signing', () => {
     store.ensureQueueEmpty();
   });
 
+  it('rejects eth_signTypedData_v4 with a non-string payload', async () => {
+    const provider = createProvider();
+    await expect(
+      provider.request({
+        method: 'eth_signTypedData_v4',
+        params: [ADDRESS_A, { not: 'a string' }],
+      }),
+    ).rejects.toThrow('eth_signTypedData_v4 arg 1 is not a string');
+  });
+
+  it('signs and broadcasts EIP-1559 transactions', async () => {
+    const { calls } = stubRpc({
+      eth_chainId: () => '0x1',
+      eth_sendRawTransaction: () => '0xtxhash',
+    });
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      SIGN_TX_1559,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: ADDRESS_A,
+            to: TX_1559.to,
+            value: '0x1',
+            gas: '0x5208',
+            maxFeePerGas: '0x77359400',
+            maxPriorityFeePerGas: '0x3b9aca00',
+            nonce: '0x0',
+            type: '0x2',
+          },
+        ],
+      }),
+    ).resolves.toBe('0xtxhash');
+
+    const expectedRaw = serializeTransaction(TX_1559, {
+      r: SIGNATURE_R,
+      s: SIGNATURE_S,
+      v: 0n,
+    });
+    expect(calls).toContainEqual({
+      method: 'eth_sendRawTransaction',
+      params: [expectedRaw],
+    });
+    store.ensureQueueEmpty();
+  });
+
+  it('signs and broadcasts EIP-2930 transactions with an access list', async () => {
+    const { calls } = stubRpc({
+      eth_chainId: () => '0x1',
+      eth_sendRawTransaction: () => '0xtxhash',
+    });
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      SIGN_TX_2930,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: ADDRESS_A,
+            to: TX_2930.to,
+            value: '0x1',
+            gas: '0x5208',
+            gasPrice: '0x3b9aca00',
+            nonce: '0x0',
+            type: '0x1',
+            accessList: [],
+          },
+        ],
+      }),
+    ).resolves.toBe('0xtxhash');
+
+    const expectedRaw = serializeTransaction(TX_2930, {
+      r: SIGNATURE_R,
+      s: SIGNATURE_S,
+      v: 0n,
+    });
+    expect(calls).toContainEqual({
+      method: 'eth_sendRawTransaction',
+      params: [expectedRaw],
+    });
+    store.ensureQueueEmpty();
+  });
+
+  it('treats an untyped transaction with gasPrice as legacy', async () => {
+    const { calls } = stubRpc({
+      eth_chainId: () => '0x1',
+      eth_sendRawTransaction: () => '0xtxhash',
+    });
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      SIGN_TX,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          {
+            from: ADDRESS_A,
+            to: LEGACY_TX.to,
+            value: '0x1',
+            gas: '0x5208',
+            gasPrice: '0x3b9aca00',
+            nonce: '0x0',
+          },
+        ],
+      }),
+    ).resolves.toBe('0xtxhash');
+
+    const expectedRaw = serializeTransaction(LEGACY_TX, {
+      r: SIGNATURE_R,
+      s: SIGNATURE_S,
+      v: 37n,
+    });
+    expect(calls).toContainEqual({
+      method: 'eth_sendRawTransaction',
+      params: [expectedRaw],
+    });
+    store.ensureQueueEmpty();
+  });
+
+  it('fills nonce, fees and gas from the node when missing', async () => {
+    const { calls } = stubRpc({
+      eth_chainId: () => '0x1',
+      eth_getTransactionCount: () => '0x0',
+      eth_gasPrice: () => '0x3b9aca00',
+      eth_estimateGas: () => '0x5208',
+      eth_getBlockByNumber: () => ({
+        number: '0x1',
+        timestamp: '0x0',
+        gasLimit: '0x1c9c380',
+        gasUsed: '0x0',
+        baseFeePerGas: null,
+        transactions: [],
+      }),
+      eth_sendRawTransaction: () => '0xtxhash',
+    });
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      SIGN_TX_FILLED,
+    );
+
+    await expect(
+      provider.request({
+        method: 'eth_sendTransaction',
+        params: [
+          { from: ADDRESS_A, to: LEGACY_TX.to, value: '0x1', type: '0x0' },
+        ],
+      }),
+    ).resolves.toBe('0xtxhash');
+
+    // The filled fields produce exactly the fixture transaction, with
+    // viem's 1.2 legacy fee multiplier applied to the node's gas price.
+    const expectedRaw = serializeTransaction(FILLED_LEGACY_TX, {
+      r: SIGNATURE_R,
+      s: SIGNATURE_S,
+      v: 37n,
+    });
+    expect(calls).toContainEqual({
+      method: 'eth_sendRawTransaction',
+      params: [expectedRaw],
+    });
+    store.ensureQueueEmpty();
+  });
+
   it('rejects eth_sendTransaction from a foreign address', async () => {
     const provider = createProvider();
     injectReplayer(provider, APP_CONFIG, getAddressExchange(ADDRESS_A));
@@ -304,6 +501,87 @@ describe('signing', () => {
         params: [{ from: ADDRESS_B, to: ADDRESS_A, value: '0x1' }],
       }),
     ).rejects.toThrow('from address mismatch');
+  });
+});
+
+describe('device lifecycle', () => {
+  it('re-reads the account when the derivation path changes', async () => {
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      APP_CONFIG,
+      getAddressExchangeForPathB(ADDRESS_B),
+    );
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toEqual(
+      [ADDRESS_A],
+    );
+
+    // The user picked another account in the wallet modal.
+    window.localStorage.setItem(LS_KEY_DERIVATION_PATH, DERIVATION_PATH_B);
+
+    await expect(provider.request({ method: 'eth_accounts' })).resolves.toEqual(
+      [ADDRESS_B],
+    );
+    expect(
+      JSON.parse(window.localStorage.getItem(LS_KEY_ACCOUNT) ?? ''),
+    ).toEqual({ address: ADDRESS_B, path: DERIVATION_PATH_B });
+    store.ensureQueueEmpty();
+  });
+
+  it('emits disconnect when the connected device is unplugged', async () => {
+    const hid = stubHid();
+    const device = {} as HIDDevice;
+    const provider = createProvider();
+    injectReplayerWithDevice(
+      provider,
+      device,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+    );
+    const onDisconnect = vi.fn();
+    provider.on('disconnect', onDisconnect);
+    await provider.enable();
+
+    // Some other HID device disappearing is not our disconnect.
+    hid.unplug({} as HIDDevice);
+    expect(onDisconnect).not.toHaveBeenCalled();
+
+    hid.unplug(device);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+
+    // The listener removed itself after firing.
+    hid.unplug(device);
+    expect(onDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes concurrent device sessions', async () => {
+    const provider = createProvider();
+    const store = injectReplayer(
+      provider,
+      APP_CONFIG,
+      getAddressExchange(ADDRESS_A),
+      // Two strictly sequential signing sessions: interleaved transport
+      // opens would consume the recorded exchanges out of order.
+      APP_CONFIG,
+      PERSONAL_SIGN,
+      APP_CONFIG,
+      PERSONAL_SIGN,
+    );
+    await provider.enable();
+
+    const sign = () =>
+      provider.request({
+        method: 'personal_sign',
+        params: [stringToHex(PERSONAL_SIGN_MESSAGE), ADDRESS_A],
+      });
+    await expect(Promise.all([sign(), sign()])).resolves.toEqual([
+      MESSAGE_SIGNATURE,
+      MESSAGE_SIGNATURE,
+    ]);
+    store.ensureQueueEmpty();
   });
 });
 

--- a/packages/connectors/ledger-connector/src/hid/helpers.ts
+++ b/packages/connectors/ledger-connector/src/hid/helpers.ts
@@ -35,7 +35,9 @@ export const checkError = (error: any): never => {
 };
 
 export const clearLedgerDerivationPath = () => {
-  window?.localStorage.removeItem(LS_KEY_DERIVATION_PATH);
+  // `window?.` is not enough: an undeclared identifier still throws in SSR.
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(LS_KEY_DERIVATION_PATH);
 };
 
 export const saveLedgerChainId = (chainId: number) => {

--- a/packages/connectors/ledger-connector/src/iframe/__tests__/connector.test.ts
+++ b/packages/connectors/ledger-connector/src/iframe/__tests__/connector.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ResourceUnavailableRpcError,
+  UserRejectedRequestError,
+  type Address,
+} from 'viem';
+import { mainnet, optimism } from 'viem/chains';
+import { idLedgerLive, ledgerLiveConnector } from '../connector';
+import {
+  FakeLedgerLive,
+  HostRpcError,
+  type HostHandlers,
+} from './fake-ledger-live';
+
+const CHECKSUMMED: Address = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+const LOWERCASE = CHECKSUMMED.toLowerCase();
+
+const setup = (handlers: HostHandlers) => {
+  const host = new FakeLedgerLive(handlers);
+  const emitter = { emit: vi.fn() };
+  const connector = ledgerLiveConnector({
+    options: {
+      eventSource: host,
+      eventTarget: host,
+      timeoutMilliseconds: 1000,
+    },
+    defaultChain: mainnet,
+  })({ chains: [mainnet, optimism], emitter } as never);
+  return { host, emitter, connector };
+};
+
+describe('connect', () => {
+  it('connects and checksums the host accounts', async () => {
+    const { connector, emitter } = setup({
+      eth_requestAccounts: () => [LOWERCASE],
+      eth_chainId: () => '0x1',
+    });
+
+    await expect(connector.connect({})).resolves.toEqual({
+      accounts: [CHECKSUMMED],
+      chainId: mainnet.id,
+    });
+    expect(connector.id).toBe(idLedgerLive);
+    expect(emitter.emit).toHaveBeenCalledWith('message', {
+      type: 'connecting',
+    });
+  });
+
+  it('returns capability-shaped accounts when asked', async () => {
+    const { connector } = setup({
+      eth_requestAccounts: () => [LOWERCASE],
+      eth_chainId: () => '0x1',
+    });
+
+    await expect(
+      connector.connect({ withCapabilities: true }),
+    ).resolves.toEqual({
+      accounts: [{ address: CHECKSUMMED, capabilities: {} }],
+      chainId: mainnet.id,
+    });
+  });
+
+  it('switches to the requested chain during connect', async () => {
+    const { connector, host } = setup({
+      eth_requestAccounts: () => [LOWERCASE],
+      eth_chainId: () => '0x1',
+      wallet_switchEthereumChain: () => null,
+    });
+
+    await expect(connector.connect({ chainId: optimism.id })).resolves.toEqual({
+      accounts: [CHECKSUMMED],
+      chainId: optimism.id,
+    });
+    expect(host.calls).toContainEqual({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: '0xa' }],
+    });
+  });
+
+  it('maps a host rejection to UserRejectedRequestError', async () => {
+    const { connector } = setup({
+      eth_requestAccounts: () => {
+        throw new HostRpcError(4001, 'User rejected request');
+      },
+    });
+
+    await expect(connector.connect({})).rejects.toBeInstanceOf(
+      UserRejectedRequestError,
+    );
+  });
+
+  it('wraps other host failures as ResourceUnavailableRpcError', async () => {
+    const { connector } = setup({
+      eth_requestAccounts: () => {
+        throw new HostRpcError(-32000, 'Ledger Live is busy');
+      },
+    });
+
+    await expect(connector.connect({})).rejects.toBeInstanceOf(
+      ResourceUnavailableRpcError,
+    );
+  });
+});
+
+describe('chain handling', () => {
+  it('reads the chain id from the host', async () => {
+    const { connector } = setup({ eth_chainId: () => '0xa' });
+    await expect(connector.getChainId()).resolves.toBe(optimism.id);
+  });
+
+  it('switches to a configured chain', async () => {
+    const { connector, host } = setup({
+      wallet_switchEthereumChain: () => null,
+    });
+
+    const chain = await connector.switchChain?.({ chainId: optimism.id });
+    expect(chain?.id).toBe(optimism.id);
+    expect(chain?.name).toBe(optimism.name);
+    expect(host.calls).toEqual([
+      { method: 'wallet_switchEthereumChain', params: [{ chainId: '0xa' }] },
+    ]);
+  });
+
+  it('fabricates a chain entry for an unconfigured chain the host accepts', async () => {
+    const { connector } = setup({ wallet_switchEthereumChain: () => null });
+
+    const chain = await connector.switchChain?.({ chainId: 137 });
+    expect(chain?.id).toBe(137);
+  });
+
+  it('maps a switch rejection to UserRejectedRequestError', async () => {
+    const { connector } = setup({
+      wallet_switchEthereumChain: () => {
+        throw new HostRpcError(4001, 'User rejected request');
+      },
+    });
+
+    await expect(
+      connector.switchChain?.({ chainId: optimism.id }),
+    ).rejects.toBeInstanceOf(UserRejectedRequestError);
+  });
+
+  it('reports unsupported switching for other host failures', async () => {
+    const { connector } = setup({
+      wallet_switchEthereumChain: () => {
+        throw new HostRpcError(-32601, 'method not available');
+      },
+    });
+
+    await expect(
+      connector.switchChain?.({ chainId: optimism.id }),
+    ).rejects.toMatchObject({ name: 'SwitchChainNotSupportedError' });
+  });
+});
+
+describe('authorization', () => {
+  it('is authorized when the host reports accounts', async () => {
+    const { connector } = setup({ eth_accounts: () => [LOWERCASE] });
+    await expect(connector.isAuthorized()).resolves.toBe(true);
+  });
+
+  it('is not authorized without accounts', async () => {
+    const { connector } = setup({ eth_accounts: () => [] });
+    await expect(connector.isAuthorized()).resolves.toBe(false);
+  });
+
+  it('is not authorized when the host errors', async () => {
+    const { connector } = setup({
+      eth_accounts: () => {
+        throw new HostRpcError(-32000, 'nope');
+      },
+    });
+    await expect(connector.isAuthorized()).resolves.toBe(false);
+  });
+});
+
+describe('host events', () => {
+  const connect = async () => {
+    const context = setup({
+      eth_requestAccounts: () => [LOWERCASE],
+      eth_chainId: () => '0x1',
+    });
+    await context.connector.connect({});
+    context.emitter.emit.mockClear();
+    return context;
+  };
+
+  it('forwards account changes to wagmi', async () => {
+    const { host, emitter } = await connect();
+
+    host.emitEvent('accountsChanged', [[LOWERCASE]]);
+    expect(emitter.emit).toHaveBeenCalledWith('change', {
+      accounts: [LOWERCASE],
+    });
+  });
+
+  it('disconnects and detaches when the host reports no accounts', async () => {
+    const { host, emitter } = await connect();
+
+    host.emitEvent('accountsChanged', [[]]);
+    expect(emitter.emit).toHaveBeenCalledWith('disconnect');
+
+    // The listeners are gone: further host events reach nobody.
+    emitter.emit.mockClear();
+    host.emitEvent('chainChanged', ['0xa']);
+    host.emitEvent('accountsChanged', [[LOWERCASE]]);
+    expect(emitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('forwards chain changes to wagmi', async () => {
+    const { host, emitter } = await connect();
+
+    host.emitEvent('chainChanged', ['0xa']);
+    expect(emitter.emit).toHaveBeenCalledWith('change', {
+      chainId: optimism.id,
+    });
+  });
+});
+
+describe('provider', () => {
+  it('exposes an EIP-1193 request wrapper over send', async () => {
+    const { connector } = setup({ eth_chainId: () => '0x1' });
+    const provider = await connector.getProvider();
+    await expect(provider.request({ method: 'eth_chainId' })).resolves.toBe(
+      '0x1',
+    );
+  });
+
+  it('caches one provider per chain', async () => {
+    const { connector } = setup({});
+    const one = await connector.getProvider();
+    const two = await connector.getProvider();
+    expect(one).toBe(two);
+  });
+});

--- a/packages/connectors/ledger-connector/src/iframe/__tests__/connector.test.ts
+++ b/packages/connectors/ledger-connector/src/iframe/__tests__/connector.test.ts
@@ -217,6 +217,83 @@ describe('host events', () => {
   });
 });
 
+describe('listener lifecycle', () => {
+  const connect = async () => {
+    const context = setup({
+      eth_requestAccounts: () => [LOWERCASE],
+      eth_chainId: () => '0x1',
+    });
+    await context.connector.connect({});
+    context.emitter.emit.mockClear();
+    return context;
+  };
+
+  it('stops forwarding host events after disconnect', async () => {
+    const { connector, host, emitter } = await connect();
+
+    await connector.disconnect();
+    emitter.emit.mockClear();
+
+    host.emitEvent('accountsChanged', [[LOWERCASE]]);
+    host.emitEvent('chainChanged', ['0xa']);
+    expect(emitter.emit).not.toHaveBeenCalled();
+  });
+
+  it('resumes forwarding after reconnecting', async () => {
+    const { connector, host, emitter } = await connect();
+
+    await connector.disconnect();
+    await connector.connect({ isReconnecting: true });
+    emitter.emit.mockClear();
+
+    host.emitEvent('accountsChanged', [[LOWERCASE]]);
+    expect(emitter.emit).toHaveBeenCalledTimes(1);
+    expect(emitter.emit).toHaveBeenCalledWith('change', {
+      accounts: [LOWERCASE],
+    });
+  });
+
+  it('does not stack listeners across repeated connects', async () => {
+    const { connector, host, emitter } = await connect();
+
+    // wagmi may call connect() again on the live connector (reconnects).
+    await connector.connect({});
+    emitter.emit.mockClear();
+
+    host.emitEvent('accountsChanged', [[LOWERCASE]]);
+    expect(emitter.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes working wagmi delegate methods', async () => {
+    const { connector, emitter } = await connect();
+
+    connector.onAccountsChanged([LOWERCASE]);
+    expect(emitter.emit).toHaveBeenCalledWith('change', {
+      accounts: [LOWERCASE],
+    });
+
+    connector.onChainChanged('0xa');
+    expect(emitter.emit).toHaveBeenCalledWith('change', {
+      chainId: optimism.id,
+    });
+
+    connector.onDisconnect?.(new Error('closed'));
+    expect(emitter.emit).toHaveBeenCalledWith('disconnect');
+  });
+
+  it('disconnects via the delegate when accounts empty out', async () => {
+    const { connector, host, emitter } = await connect();
+
+    connector.onAccountsChanged([]);
+    expect(emitter.emit).toHaveBeenCalledWith('disconnect');
+
+    // The delegate detaches the host listeners too.
+    emitter.emit.mockClear();
+    host.emitEvent('chainChanged', ['0xa']);
+    expect(emitter.emit).not.toHaveBeenCalled();
+  });
+});
+
 describe('provider', () => {
   it('exposes an EIP-1193 request wrapper over send', async () => {
     const { connector } = setup({ eth_chainId: () => '0x1' });

--- a/packages/connectors/ledger-connector/src/iframe/__tests__/fake-ledger-live.ts
+++ b/packages/connectors/ledger-connector/src/iframe/__tests__/fake-ledger-live.ts
@@ -1,0 +1,76 @@
+import type {
+  MinimalEventSourceInterface,
+  MinimalEventTargetInterface,
+} from '@ledgerhq/iframe-provider';
+
+type JsonRpcRequest = {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params?: unknown[];
+};
+
+export type HostHandlers = Record<string, (params: unknown[]) => unknown>;
+
+// A handler throws this to make the host answer with a JSON-RPC error.
+export class HostRpcError extends Error {
+  constructor(
+    public readonly code: number,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+// Simulates the Ledger Live host on the other side of the iframe bridge:
+// the provider posts JSON-RPC requests into `postMessage` and receives
+// responses (and host-initiated events) through its message listeners.
+export class FakeLedgerLive
+  implements MinimalEventSourceInterface, MinimalEventTargetInterface
+{
+  readonly calls: { method: string; params: unknown[] }[] = [];
+
+  private listeners = new Set<(event: MessageEvent) => void>();
+
+  constructor(private readonly handlers: HostHandlers) {}
+
+  addEventListener(_type: 'message', listener: (event: MessageEvent) => void) {
+    this.listeners.add(listener);
+  }
+
+  postMessage(message: JsonRpcRequest) {
+    this.calls.push({ method: message.method, params: message.params ?? [] });
+    const handler = this.handlers[message.method];
+    // Real replies arrive on a later tick, never synchronously.
+    queueMicrotask(() => {
+      try {
+        if (!handler)
+          throw new HostRpcError(-32601, `no handler for ${message.method}`);
+        this.dispatch({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: handler(message.params ?? []),
+        });
+      } catch (error) {
+        const { code = -32000, message: reason = 'host error' } =
+          error as Partial<HostRpcError>;
+        this.dispatch({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: { code, message: reason },
+        });
+      }
+    });
+  }
+
+  // A host-initiated event (accountsChanged, chainChanged, …).
+  emitEvent(method: string, params: unknown[]) {
+    this.dispatch({ jsonrpc: '2.0', method, params });
+  }
+
+  private dispatch(data: unknown) {
+    this.listeners.forEach((listener) =>
+      listener({ data } as unknown as MessageEvent),
+    );
+  }
+}

--- a/packages/connectors/ledger-connector/src/iframe/__tests__/helpers.test.ts
+++ b/packages/connectors/ledger-connector/src/iframe/__tests__/helpers.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isIframe, isLedgerLive } from '../helpers';
+
+const originalParent = window.parent;
+
+// happy-dom is a top-level window: parent === window. Pretend to be embedded.
+const embedInIframe = () => {
+  Object.defineProperty(window, 'parent', {
+    value: {} as Window,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  Object.defineProperty(window, 'parent', {
+    value: originalParent,
+    configurable: true,
+  });
+  window.history.replaceState(null, '', '/');
+});
+
+describe('isIframe', () => {
+  it('is false for a top-level window', () => {
+    expect(isIframe()).toBe(false);
+  });
+
+  it('is true inside an iframe', () => {
+    embedInIframe();
+    expect(isIframe()).toBe(true);
+  });
+});
+
+describe('isLedgerLive', () => {
+  it('is false for a top-level window', () => {
+    expect(isLedgerLive()).toBe(false);
+  });
+
+  it('is false in an iframe without the embed marker', () => {
+    embedInIframe();
+    expect(isLedgerLive()).toBe(false);
+  });
+
+  it('is true in an iframe with the embed marker', () => {
+    embedInIframe();
+    window.history.replaceState(null, '', '/?embed=true');
+    expect(isLedgerLive()).toBe(true);
+  });
+
+  it('is false with the embed marker outside an iframe', () => {
+    window.history.replaceState(null, '', '/?embed=true');
+    expect(isLedgerLive()).toBe(false);
+  });
+});

--- a/packages/connectors/ledger-connector/src/iframe/connector.ts
+++ b/packages/connectors/ledger-connector/src/iframe/connector.ts
@@ -30,139 +30,160 @@ export function ledgerLiveConnector({
 }: LedgerLiveConnectorArgs) {
   const providers: Record<Chain['id'], LedgerIFrameProvider> = {};
 
-  return createConnector<LedgerIFrameProvider>(({ chains, emitter }) => ({
-    id: idLedgerLive,
-    name,
-    type: ledgerLiveConnector.type,
-
-    async getProvider({ chainId } = {}) {
-      const chain = chains.find((x) => x.id === chainId) ?? defaultChain;
-      if (!providers[chain.id]) {
-        const { LedgerIFrameProvider } = await import('./provider');
-        providers[chain.id] = new LedgerIFrameProvider(options);
-      }
-      return providers[chain.id];
-    },
-
-    async connect({
-      chainId,
-      withCapabilities,
-    }: {
-      chainId?: number;
-      isReconnecting?: boolean;
-      withCapabilities?: boolean;
-    } = {}) {
-      try {
-        const provider = await this.getProvider();
-
-        // works without bind because it's an obj created(scoped) in a function
-        provider.on('accountsChanged', this.onAccountsChanged);
-        provider.on('chainChanged', this.onChainChanged);
-
-        emitter.emit('message', { type: 'connecting' });
-
-        const accounts = await this.getAccounts();
-        let currentChainId = await this.getChainId();
-
-        if (chainId && currentChainId !== chainId && this.switchChain) {
-          const chain = await this.switchChain({ chainId });
-          currentChainId = chain.id;
+  return createConnector<LedgerIFrameProvider>(({ chains, emitter }) => {
+    // eventemitter3 invokes listeners with the provider as `this`, so these
+    // are standalone closures rather than connector methods — `this` inside
+    // a connector method used as a listener would resolve to the provider.
+    const handlers = {
+      onAccountsChanged: (accounts: Address[]) => {
+        if (accounts.length === 0 || !accounts[0]) {
+          emitter.emit('disconnect');
+          handlers.detach();
+        } else {
+          emitter.emit('change', { accounts });
         }
-
-        return {
-          accounts: (withCapabilities
-            ? accounts.map((address) => ({ address, capabilities: {} }))
-            : accounts) as never,
-          chainId: currentChainId,
-        };
-      } catch (error) {
-        if (error instanceof Error) {
-          if ((error as ProviderRpcError).code === 4001) {
-            throw new UserRejectedRequestError(error);
-          }
-          throw new ResourceUnavailableRpcError(error);
-        }
-
-        throw error;
-      }
-    },
-
-    async switchChain({ chainId }) {
-      const provider = await this.getProvider();
-      const id = numberToHex(chainId);
-
-      try {
-        await provider.send('wallet_switchEthereumChain', [{ chainId: id }]);
-
-        return (
-          chains.find((x) => x.id === chainId) ?? {
-            id: chainId,
-            name: `Chain ${id}`,
-            network: `${id}`,
-            nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
-            rpcUrls: { default: { http: [''] }, public: { http: [''] } },
-          }
-        );
-      } catch (error) {
-        const message =
-          typeof error === 'string'
-            ? error
-            : (error as ProviderRpcError)?.message;
-        if (/user rejected request/i.test(message)) {
-          throw new UserRejectedRequestError(error as Error);
-        }
-        throw new SwitchChainNotSupportedError({
-          connector: { name } as Connector, // only name is needed to generate an error message
+      },
+      onChainChanged: (chainId: number | string) => {
+        emitter.emit('change', { chainId: Number(chainId) });
+      },
+      detach: () => {
+        Object.values(providers).forEach((provider) => {
+          provider.removeListener(
+            'accountsChanged',
+            handlers.onAccountsChanged,
+          );
+          provider.removeListener('chainChanged', handlers.onChainChanged);
         });
-      }
-    },
+      },
+    };
 
-    async getAccounts() {
-      const provider = await this.getProvider();
-      const accounts = await provider.send('eth_requestAccounts');
-      // Checksum each address; the explicit lambda keeps Array.map's index
-      // out of getAddress's second (chainId, EIP-1191) parameter.
-      return accounts.map((account: string) => getAddress(account));
-    },
+    return {
+      id: idLedgerLive,
+      name,
+      type: ledgerLiveConnector.type,
 
-    async getChainId() {
-      const provider = await this.getProvider();
-      const chainId = await provider.send('eth_chainId');
-      return Number(chainId);
-    },
+      async getProvider({ chainId } = {}) {
+        const chain = chains.find((x) => x.id === chainId) ?? defaultChain;
+        if (!providers[chain.id]) {
+          const { LedgerIFrameProvider } = await import('./provider');
+          providers[chain.id] = new LedgerIFrameProvider(options);
+        }
+        return providers[chain.id];
+      },
 
-    async isAuthorized() {
-      try {
+      async connect({
+        chainId,
+        withCapabilities,
+      }: {
+        chainId?: number;
+        isReconnecting?: boolean;
+        withCapabilities?: boolean;
+      } = {}) {
+        try {
+          const provider = await this.getProvider();
+
+          provider.on('accountsChanged', handlers.onAccountsChanged);
+          provider.on('chainChanged', handlers.onChainChanged);
+
+          emitter.emit('message', { type: 'connecting' });
+
+          const accounts = await this.getAccounts();
+          let currentChainId = await this.getChainId();
+
+          if (chainId && currentChainId !== chainId && this.switchChain) {
+            const chain = await this.switchChain({ chainId });
+            currentChainId = chain.id;
+          }
+
+          return {
+            accounts: (withCapabilities
+              ? accounts.map((address) => ({ address, capabilities: {} }))
+              : accounts) as never,
+            chainId: currentChainId,
+          };
+        } catch (error) {
+          if (error instanceof Error) {
+            if ((error as ProviderRpcError).code === 4001) {
+              throw new UserRejectedRequestError(error);
+            }
+            throw new ResourceUnavailableRpcError(error);
+          }
+
+          throw error;
+        }
+      },
+
+      async switchChain({ chainId }) {
         const provider = await this.getProvider();
-        const accounts = await provider.send('eth_accounts');
-        const account = accounts[0];
-        return !!account;
-      } catch {
-        return false;
-      }
-    },
+        const id = numberToHex(chainId);
 
-    onAccountsChanged(accounts: Address[]) {
-      if (accounts.length === 0 || !accounts[0]) {
+        try {
+          await provider.send('wallet_switchEthereumChain', [{ chainId: id }]);
+
+          return (
+            chains.find((x) => x.id === chainId) ?? {
+              id: chainId,
+              name: `Chain ${id}`,
+              network: `${id}`,
+              nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
+              rpcUrls: { default: { http: [''] }, public: { http: [''] } },
+            }
+          );
+        } catch (error) {
+          const message =
+            typeof error === 'string'
+              ? error
+              : (error as ProviderRpcError)?.message;
+          if (/user rejected request/i.test(message)) {
+            throw new UserRejectedRequestError(error as Error);
+          }
+          throw new SwitchChainNotSupportedError({
+            connector: { name } as Connector, // only name is needed to generate an error message
+          });
+        }
+      },
+
+      async getAccounts() {
+        const provider = await this.getProvider();
+        const accounts = await provider.send('eth_requestAccounts');
+        // Checksum each address; the explicit lambda keeps Array.map's index
+        // out of getAddress's second (chainId, EIP-1191) parameter.
+        return accounts.map((account: string) => getAddress(account));
+      },
+
+      async getChainId() {
+        const provider = await this.getProvider();
+        const chainId = await provider.send('eth_chainId');
+        return Number(chainId);
+      },
+
+      async isAuthorized() {
+        try {
+          const provider = await this.getProvider();
+          const accounts = await provider.send('eth_accounts');
+          const account = accounts[0];
+          return !!account;
+        } catch {
+          return false;
+        }
+      },
+
+      onAccountsChanged(accounts: string[]) {
+        handlers.onAccountsChanged(accounts as Address[]);
+      },
+
+      onChainChanged(chainId: number | string) {
+        handlers.onChainChanged(chainId);
+      },
+
+      // eslint-disable-next-line @typescript-eslint/require-await
+      async disconnect() {
+        handlers.detach();
+      },
+
+      onDisconnect() {
         emitter.emit('disconnect');
-        void this.disconnect();
-      } else {
-        emitter.emit('change', { accounts });
-      }
-    },
-
-    onChainChanged(chainId: number | string) {
-      emitter.emit('change', { chainId: Number(chainId) });
-    },
-
-    async disconnect() {
-      const provider = await this.getProvider();
-      provider.removeListener('accountsChanged', this.onAccountsChanged);
-      provider.removeListener('chainChanged', this.onChainChanged);
-    },
-
-    onDisconnect() {
-      emitter.emit('disconnect');
-    },
-  }));
+      },
+    };
+  });
 }

--- a/packages/connectors/ledger-connector/src/iframe/connector.ts
+++ b/packages/connectors/ledger-connector/src/iframe/connector.ts
@@ -82,6 +82,10 @@ export function ledgerLiveConnector({
         try {
           const provider = await this.getProvider();
 
+          // eventemitter3 stacks duplicate listeners, and wagmi may call
+          // connect() repeatedly on a live connector — detach first so every
+          // host event is forwarded exactly once.
+          handlers.detach();
           provider.on('accountsChanged', handlers.onAccountsChanged);
           provider.on('chainChanged', handlers.onChainChanged);
 
@@ -103,7 +107,7 @@ export function ledgerLiveConnector({
           };
         } catch (error) {
           if (error instanceof Error) {
-            if ((error as ProviderRpcError).code === 4001) {
+            if ((error as ProviderRpcError)?.code === 4001) {
               throw new UserRejectedRequestError(error);
             }
             throw new ResourceUnavailableRpcError(error);

--- a/packages/connectors/ledger-connector/tsconfig.json
+++ b/packages/connectors/ledger-connector/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.*"],
+  "exclude": ["node_modules", "dist"],
   "compilerOptions": {
     "rootDir": "src",
   }

--- a/packages/connectors/ledger-connector/vitest.config.ts
+++ b/packages/connectors/ledger-connector/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'happy-dom',
+    include: ['src/**/*.test.ts'],
+    server: {
+      deps: {
+        // The @ledgerhq ESM builds use extensionless relative imports that
+        // Node cannot resolve natively — let vite's resolver process them.
+        inline: [/@ledgerhq\//],
+      },
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,6 +3542,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.6.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.6.0"
+  checksum: 10/eb53fbf7eb4051302a599d6b91425f381168b2856f321336fb00852cea1e0c1904af2610c157b1535e94a61caa98f0bd068d1d0394dd46adf9e9c45c4e11af91
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
@@ -3632,7 +3639,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-mocker@npm:^6.34.7":
+"@ledgerhq/hw-transport-mocker@npm:6.34.7, @ledgerhq/hw-transport-mocker@npm:^6.34.7":
   version: 6.34.7
   resolution: "@ledgerhq/hw-transport-mocker@npm:6.34.7"
   dependencies:
@@ -4092,6 +4099,13 @@ __metadata:
   dependencies:
     multiformats: "npm:^13.0.0"
   checksum: 10/6123ae9fecbccf25deed09a1675b1128e94509c8781de21d129232dd219dc93a8bee206332fda30b352bd3f423966f06957ab7b0dea0cfb4680b5be717aa1f5b
+  languageName: node
+  linkType: hard
+
+"@napi-rs/lzma-linux-x64-gnu@npm:1.5.1":
+  version: 1.5.1
+  resolution: "@napi-rs/lzma-linux-x64-gnu@npm:1.5.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -4906,12 +4920,15 @@ __metadata:
   dependencies:
     "@ledgerhq/hw-app-eth": "npm:7.8.12"
     "@ledgerhq/hw-transport": "npm:6.35.7"
+    "@ledgerhq/hw-transport-mocker": "npm:6.34.7"
     "@ledgerhq/hw-transport-webhid": "npm:6.36.0"
     "@ledgerhq/iframe-provider": "npm:^0.4.3"
     "@types/w3c-web-hid": "npm:^1.0.7"
     build-config: "npm:*"
     eslint-config-custom: "npm:*"
+    happy-dom: "npm:^20.0.0"
     viem: "npm:>=2.50"
+    vitest: "npm:^3.2.4"
     wagmi: "npm:>=3.6"
   peerDependencies:
     "@tanstack/react-query": ^5.29.0
@@ -5525,6 +5542,181 @@ __metadata:
     estree-walker: "npm:^2.0.1"
     picomatch: "npm:^2.2.2"
   checksum: 10/503a6f0a449e11a2873ac66cfdfb9a3a0b77ffa84c5cad631f5e4bc1063c850710e8d5cd5dab52477c0d66cda2ec719865726dbe753318cd640bab3fff7ca476
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm-eabi@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.63.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-android-arm64@npm:4.63.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.63.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-darwin-x64@npm:4.63.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.63.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.63.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.63.1"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.63.1"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.63.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.63.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.63.1"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.63.1"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.63.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.63.1"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.63.1"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.63.1"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.63.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.63.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.63.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.63.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.63.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.63.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.63.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.63.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.63.1":
+  version: 4.63.1
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.63.1"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -7203,6 +7395,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10/e79947307dc235953622e65f83d2683835212357ca261389116ab90bed369ac862ba28b146b4fed08b503ae1e1a12cb93ce783f24bb8d562950469f4320e1c7c
+  languageName: node
+  linkType: hard
+
 "@types/connect@npm:^3.4.33":
   version: 3.4.38
   resolution: "@types/connect@npm:3.4.38"
@@ -7218,6 +7420,20 @@ __metadata:
   dependencies:
     "@types/ms": "npm:*"
   checksum: 10/47876a852de8240bfdaf7481357af2b88cb660d30c72e73789abf00c499d6bc7cd5e52f41c915d1b9cd8ec9fef5b05688d7b7aef17f7f272c2d04679508d1053
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10/249a27b0bb22f6aa28461db56afa21ec044fa0e303221a62dff81831b20c8530502175f1a49060f7099e7be06181078548ac47c668de79ff9880241968d43d0c
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.9, @types/estree@npm:^1.0.0":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10/16aabfa703b5bdac83f719b07ce92a11b2d3c9b8628eacc92889d8af46cab2d78fc45c7b5378de383d0500585cea5c2f79125eeddfe5fbc6bd6a27eb0c8ccee5
   languageName: node
   linkType: hard
 
@@ -7281,6 +7497,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~8.3.0"
   checksum: 10/fee720e8ddf8aa66a22bc5cf3209347f8dcc07cbf7475f966761684f04fb34b819739a311edbf87271d6c7f9f50b1f015d3ff9e36d67d04264aafe18ac9a3796
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=20.0.0":
+  version: 26.5.0
+  resolution: "@types/node@npm:26.5.0"
+  dependencies:
+    undici-types: "npm:~8.9.0"
+  checksum: 10/db4b0ac5289abaf7fa6f280610853a3a9c88cd60ef686513fb773badf77bbf6089cafc9522bc99d0765f13b43cde3109b37a8183859a2adeec00ae07f0a4710d
   languageName: node
   linkType: hard
 
@@ -7464,6 +7689,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10/609607beeaa8b50b9e00541d8f571880d651b26b6b006103370099aba00784037de54433627c9fe775a5558e3d1fc09c2a48f54c8af91988e9bebeaf6a698eeb
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^7.4.4":
   version: 7.4.7
   resolution: "@types/ws@npm:7.4.7"
@@ -7473,7 +7705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.2.2":
+"@types/ws@npm:^8.18.1, @types/ws@npm:^8.2.2":
   version: 8.18.1
   resolution: "@types/ws@npm:8.18.1"
   dependencies:
@@ -7825,6 +8057,89 @@ __metadata:
   version: 1.12.2
   resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.12.2"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/expect@npm:3.2.7"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:3.2.7"
+    "@vitest/utils": "npm:3.2.7"
+    chai: "npm:^5.2.0"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10/2621cf1e90880b6c35de0aebc4a429380036b51b66f8ba7cab8643a7476f6fc2b23bb25a7db0e05ad2fb2fb196e2070ba35b671e3bc9adb967b7549b055a6514
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/mocker@npm:3.2.7"
+  dependencies:
+    "@vitest/spy": "npm:3.2.7"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.17"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10/fccb77857ad4ba424e9298eac0c61e95592cf594244291c20fde68a40bca970aa5ba7193cc339aea5e0378ccd01f73feb56d34742c087a220202feb53fdc31f7
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:3.2.7, @vitest/pretty-format@npm:^3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/pretty-format@npm:3.2.7"
+  dependencies:
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10/81286f667f799a11d8c6e2d16344b96baa502fb3fa9a54ef8c2e40d13d4db24277a717d5a30892614b5f9d1d4c7de4b8b1e7557d0dcd0ed5fff753fda139fa43
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/runner@npm:3.2.7"
+  dependencies:
+    "@vitest/utils": "npm:3.2.7"
+    pathe: "npm:^2.0.3"
+    strip-literal: "npm:^3.0.0"
+  checksum: 10/ff7c14726c3e3c3d88a8952f54cf56c82f3de96d1421d1ba21291a4fbe37f1bb94ed091a032a26b2b4acf9b0ce7fa6e4993191a6ada82775dfe32fa5527f88a4
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/snapshot@npm:3.2.7"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.7"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+  checksum: 10/8d1bc49c1d517a1112d03d244dbb9b8e81e47ef0f6b99267624fc936fcb699c920f3ba56236f69895d34b036014efea4277fce3bc46492452c7ed0df4944aeeb
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/spy@npm:3.2.7"
+  dependencies:
+    tinyspy: "npm:^4.0.3"
+  checksum: 10/a125bff0eca23b4e4bf73fde0742879d1e68010e0c0bcb5865f20675cba4aa8b929b437e47c280e0e59d18d289f986b087f937d3374221ccaf5a3d82e278cb8c
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:3.2.7":
+  version: 3.2.7
+  resolution: "@vitest/utils@npm:3.2.7"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.7"
+    loupe: "npm:^3.1.4"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10/d17fda64b608d06026627eaa062893215a96f61ad2b6fda6441e367d6fb41993600fa6199295ac9b171b90e53e4634efcbe0899230aa87fadcf7846b0e2cfe74
   languageName: node
   linkType: hard
 
@@ -8983,6 +9298,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10/a0789dd882211b87116e81e2648ccb7f60340b34f19877dd020b39ebb4714e475eb943e14ba3e22201c221ef6645b7bfe10297e76b6ac95b48a9898c1211ce66
+  languageName: node
+  linkType: hard
+
 "ast-types-flow@npm:^0.0.8":
   version: 0.0.8
   resolution: "ast-types-flow@npm:0.0.8"
@@ -9430,6 +9752,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-image-size@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "buffer-image-size@npm:0.6.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/82d4ca9bc8e71c9c0cbc74191d3613100d0a20dd21da018c6f373d7dc88ec4a9225eebe06c44a982de074f695402e81ab8a8daa40afce36b915042fa9fb32c52
+  languageName: node
+  linkType: hard
+
 "buffer@npm:6.0.3, buffer@npm:^6.0.3, buffer@npm:~6.0.3":
   version: 6.0.3
   resolution: "buffer@npm:6.0.3"
@@ -9462,6 +9793,13 @@ __metadata:
   version: 3.3.0
   resolution: "builtin-modules@npm:3.3.0"
   checksum: 10/62e063ab40c0c1efccbfa9ffa31873e4f9d57408cb396a2649981a0ecbce56aabc93c28feaccbc5658c95aab2703ad1d11980e62ec2e5e72637404e1eb60f39e
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10/002769a0fbfc51c062acd2a59df465a2a947916b02ac50b56c69ec6c018ee99ac3e7f4dd7366334ea847f1ecacf4defaa61bcd2ac283db50156ce1f1d8c8ad42
   languageName: node
   linkType: hard
 
@@ -9606,6 +9944,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^5.2.0":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10/0d0ef63106083b05c7ba510697cd9991a02b8df5984a7d010ab4af10205c7a1f27d1c06bfa4679540894295ac4dcc22aa2a281e2e4cfe5133c1db379626689a2
+  languageName: node
+  linkType: hard
+
 "chalk@npm:5.6.2, chalk@npm:^5.4.1, chalk@npm:^5.6.2":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
@@ -9652,6 +10003,13 @@ __metadata:
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
   checksum: 10/81dcadbe57e861d527faf6dd3855dc857395a1c4d6781f4847288ab23cffb7b3ee80d57c15bba7252ffe3e5e8019db767757ee7975663ad2ca0939bb8fcaf2e5
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10/f1868d3db60f5a7da92e140ccf33e9152bf6124161fa9b7a4ae8eafdb05e66e1f13570401e56f314f037b0f1b71eaf38ad0c7256310d82c6105e9d85ded0f202
   languageName: node
   linkType: hard
 
@@ -10417,7 +10775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -10442,6 +10800,13 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10/ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
+  languageName: node
+  linkType: hard
+
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10/a529b81e2ef8821621d20a36959a0328873a3e49d393ad11f8efe8559f31239494c2eb889b80342808674c475802ba95b9d6c4c27641b9a029405104c1b59fcf
   languageName: node
   linkType: hard
 
@@ -10935,6 +11300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10/3c0c58d869c45148463e96d21dee2d1b801bd3fe4cf47aa470cd26dfe81d59e9e0a9be92ae083fa02fa441283c883a471486e94538dcfb8544428aa80a55271b
+  languageName: node
+  linkType: hard
+
 "env-ci@npm:^11.0.0, env-ci@npm:^11.2.0":
   version: 11.2.0
   resolution: "env-ci@npm:11.2.0"
@@ -11158,6 +11530,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10/b6f3e576a3fed4d82b0d0ad4bbf6b3a5ad694d2e7ce8c4a069560da3db6399381eaba703616a182b16dde50ce998af64e07dcf49f2ae48153b9e07be3f107087
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -11259,7 +11638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.28.1":
+"esbuild@npm:^0.27.0 || ^0.28.0, esbuild@npm:^0.28.1":
   version: 0.28.2
   resolution: "esbuild@npm:0.28.2"
   dependencies:
@@ -11805,6 +12184,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10/a65728d5727b71de172c5df323385755a16c0fdab8234dc756c3854cfee343261ddfbb72a809a5660fac8c75d960bb3e21aa898c2d7e9b19bb298482ca58a3af
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -11899,6 +12287,13 @@ __metadata:
     strip-final-newline: "npm:^4.0.0"
     yoctocolors: "npm:^2.1.1"
   checksum: 10/d0f7a2185152379f8772f6d780b188f2728a95b9a68d1a897f58805d7ba6bd55eaa5e128cb66a274251a6b5e4d9388332b1417bd7d46c25e020e4e55725cf79e
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.2.1":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10/bad91f4b7eb807248695ee840a935d12818fe531ad523bc7ac7dcc540a4d86dc566a3ef829f4da6e8b5a458ac84092771739865114c91e7e8a9317302f401f09
   languageName: node
   linkType: hard
 
@@ -12270,7 +12665,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -12280,7 +12675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -12689,6 +13084,21 @@ __metadata:
   bin:
     handlebars: bin/handlebars
   checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^20.0.0":
+  version: 20.14.0
+  resolution: "happy-dom@npm:20.14.0"
+  dependencies:
+    "@types/node": "npm:>=20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    "@types/ws": "npm:^8.18.1"
+    buffer-image-size: "npm:^0.6.4"
+    entities: "npm:^7.0.1"
+    whatwg-mimetype: "npm:^3.0.0"
+    ws: "npm:^8.21.0"
+  checksum: 10/d6cc3d22c4cec42e163225eddf2afe7fe9c98d38a69d5870d0b6195c83478f0d833c9747ba44f4a3cfb99f94d0c6ce4ab9a5b8174e8500a8d6b7f53f21bc0426
   languageName: node
   linkType: hard
 
@@ -13948,6 +14358,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "js-tokens@npm:9.0.1"
+  checksum: 10/3288ba73bb2023adf59501979fb4890feb6669cc167b13771b226814fde96a1583de3989249880e3f4d674040d1815685db9a9880db9153307480d39dc760365
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^4.3.1":
   version: 4.3.2
   resolution: "js-yaml@npm:4.3.2"
@@ -14534,6 +14951,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loupe@npm:^3.1.0, loupe@npm:^3.1.4":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10/a4d78ec758aaa04e0e35d5cd1c15e970beb9cdbfd3d0f34f98b9bcda489f896a7190b3b6cc40b7a6dcb8e97e82e96eafaae10096aaa469804acdba6f7c2bde5f
+  languageName: node
+  linkType: hard
+
 "lower-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "lower-case@npm:2.0.2"
@@ -14572,6 +14996,15 @@ __metadata:
   bin:
     lz-string: bin/bin.js
   checksum: 10/e86f0280e99a8d8cd4eef24d8601ddae15ce54e43ac9990dfcb79e1e081c255ad24424a30d78d2ad8e51a8ce82a66a930047fed4b4aa38c6f0b392ff9300edfc
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.17":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10/57d5691f41ed40d962d8bd300148114f53db67fadbff336207db10a99f2bdf4a1be9cac3a68ee85dba575912ee1d4402e4396408196ec2d3afd043b076156221
   languageName: node
   linkType: hard
 
@@ -15029,7 +15462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.4":
+"nanoid@npm:^3.3.18, nanoid@npm:^3.3.4":
   version: 3.3.18
   resolution: "nanoid@npm:3.3.18"
   bin:
@@ -16185,6 +16618,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10/01e9a69928f39087d96e1751ce7d6d50da8c39abf9a12e0ac2389c42c83bc76f78c45a475bd9026a02e6a6f79be63acc75667df855862fe567d99a00a540d23d
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10/f5e8b82f6b988a5bba197970af050268fd800780d0f9ee026e6f0b544ac4b17ab52bebeabccb790d63a794530a1641ae399ad07ecfc67ad337504c85dc9e5693
+  languageName: node
+  linkType: hard
+
 "performance-now@npm:^2.1.0":
   version: 2.1.0
   resolution: "performance-now@npm:2.1.0"
@@ -16206,17 +16653,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.5":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10/66e1df34bc39c72fa3756be4069f7887ea3e35e94bba1c3f6167763007698cb04b8a0a365161d186fda6e9571a2d3efb606b2966eb6a7dea6252911224dc2f48
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.5":
-  version: 4.0.7
-  resolution: "picomatch@npm:4.0.7"
-  checksum: 10/66e1df34bc39c72fa3756be4069f7887ea3e35e94bba1c3f6167763007698cb04b8a0a365161d186fda6e9571a2d3efb606b2966eb6a7dea6252911224dc2f48
   languageName: node
   linkType: hard
 
@@ -16350,6 +16797,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 10/1940e8d1da04a2ac3e518735ab3e9563e2255bfab14cecc8c11fee97b2a36ac5fee496bccfc7057aaae7ff3accae463cd800d746238cf691bd65a32dba5cb7be
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.6":
+  version: 8.5.28
+  resolution: "postcss@npm:8.5.28"
+  dependencies:
+    nanoid: "npm:^3.3.18"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10/c34814c1da499f370cd3b02a085a2d866989a966629b7bd4025f4a2a10d538a2ec83dc3181e1008550edb4cf44e49a0c40ec82332b08d9600877e6841240ad05
   languageName: node
   linkType: hard
 
@@ -17428,6 +17886,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.43.0":
+  version: 4.63.1
+  resolution: "rollup@npm:4.63.1"
+  dependencies:
+    "@napi-rs/lzma-linux-x64-gnu": "npm:1.5.1"
+    "@rollup/rollup-android-arm-eabi": "npm:4.63.1"
+    "@rollup/rollup-android-arm64": "npm:4.63.1"
+    "@rollup/rollup-darwin-arm64": "npm:4.63.1"
+    "@rollup/rollup-darwin-x64": "npm:4.63.1"
+    "@rollup/rollup-freebsd-arm64": "npm:4.63.1"
+    "@rollup/rollup-freebsd-x64": "npm:4.63.1"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.63.1"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.63.1"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.63.1"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.63.1"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.63.1"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.63.1"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.63.1"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.63.1"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.63.1"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.63.1"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.63.1"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.63.1"
+    "@rollup/rollup-linux-x64-musl": "npm:4.63.1"
+    "@rollup/rollup-openbsd-x64": "npm:4.63.1"
+    "@rollup/rollup-openharmony-arm64": "npm:4.63.1"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.63.1"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.63.1"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.63.1"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.63.1"
+    "@types/estree": "npm:1.0.9"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@napi-rs/lzma-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10/bee523dab27406b9bc85869e134638c275148dd79e338fea1f22c5ab96b2751d21b0a69d6130669039c7b4209189d1c3b3d3d040b5024c668a2b173f2ca16e6e
+  languageName: node
+  linkType: hard
+
 "rpc-websockets@npm:^9.0.2":
   version: 9.3.2
   resolution: "rpc-websockets@npm:9.3.2"
@@ -17823,6 +18374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10/e93ff66c6531a079af8fb217240df01f980155b5dc408d2d7bebc398dd284e383eb318153bf8acd4db3c4fe799aa5b9a641e38b0ba3b1975700b1c89547ea4e7
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -17950,6 +18508,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10/ff9d8c8bf096d534a5b7707e0382ef827b4dd360a577d3f34d2b9f48e12c9d230b5747974ee7c607f0df65113732711bb701fe9ece3c7edbd43cb2294d707df3
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -18074,6 +18639,20 @@ __metadata:
   version: 0.0.10
   resolution: "stack-trace@npm:0.0.10"
   checksum: 10/7bd633f0e9ac46e81a0b0fe6538482c1d77031959cf94478228731709db4672fbbed59176f5b9a9fd89fec656b5dae03d084ef2d1b0c4c2f5683e05f2dbb1405
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10/2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.9.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10/19c9cda4f370b1ffae2b8b08c72167d8c3e5cfa972aaf5c6873f85d0ed2faa729407f5abb194dc33380708c00315002febb6f1e1b484736bfcf9361ad366013a
   languageName: node
   linkType: hard
 
@@ -18365,6 +18944,15 @@ __metadata:
   version: 2.0.1
   resolution: "strip-json-comments@npm:2.0.1"
   checksum: 10/1074ccb63270d32ca28edfb0a281c96b94dc679077828135141f27d52a5a398ef5e78bcf22809d23cadc2b81dfbe345eb5fd8699b385c8b1128907dec4a7d1e1
+  languageName: node
+  linkType: hard
+
+"strip-literal@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "strip-literal@npm:3.1.0"
+  dependencies:
+    js-tokens: "npm:^9.0.1"
+  checksum: 10/6eb00906a1c343a1050579d1d6023e067a2d72152edb92e64cad49535115beb2e77905ace24aa459f29b66e75edba75ef9d8eca90575b0322640d64a5d37e131
   languageName: node
   linkType: hard
 
@@ -18693,6 +19281,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10/cfa1e1418e91289219501703c4693c70708c91ffb7f040fd318d24aef419fb5a43e0c0160df9471499191968b2451d8da7f8087b08c3133c251c40d24aced06c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10/b9d5fed3166fb1acd1e7f9a89afcd97ccbe18b9c1af0278e429455f6976d69271ba2d21797e7c36d57d6b05025e525d2882d88c2ab435b60d1ddf2fea361de57
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.2.4":
   version: 1.3.0
   resolution: "tinyexec@npm:1.3.0"
@@ -18700,13 +19302,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.17":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.13, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
   checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10/0d54139e9dbc6ef33349768fa78890a4d708d16a7ab68e4e4ef3bb740609ddf0f9fd13292c2f413fbba756166c97051a657181c8f7ae92ade690604f183cc01d
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "tinyrainbow@npm:2.0.0"
+  checksum: 10/94d4e16246972614a5601eeb169ba94f1d49752426312d3cf8cc4f2cc663a2e354ffc653aa4de4eebccbf9eeebdd0caef52d1150271fdfde65d7ae7f3dcb9eb5
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^4.0.3":
+  version: 4.0.6
+  resolution: "tinyspy@npm:4.0.6"
+  checksum: 10/7cbf5b72b5319bb2e52b8b3fa4329a016fd3ddb7c1195d225263027a88bb4f09958942f3bedecaf419cd405c9c2998c92120c0b994e8b9b224d07e422ebb270e
   languageName: node
   linkType: hard
 
@@ -19314,6 +19937,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~8.9.0":
+  version: 8.9.0
+  resolution: "undici-types@npm:8.9.0"
+  checksum: 10/8785591929de2b71d281c684e915c4a8c41becc225adbf42a3e89148f8b384724a21533494c30a1cbb85b4cbccd088d020788ff4f2d605013eb2863cd47a1639
+  languageName: node
+  linkType: hard
+
 "undici@npm:^6.23.0, undici@npm:^6.25.0":
   version: 6.28.0
   resolution: "undici@npm:6.28.0"
@@ -19812,6 +20442,132 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:3.2.4":
+  version: 3.2.4
+  resolution: "vite-node@npm:3.2.4"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.4.1"
+    es-module-lexer: "npm:^1.7.0"
+    pathe: "npm:^2.0.3"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10/343244ecabbab3b6e1a3065dabaeefa269965a7a7c54652d4b7a7207ee82185e887af97268c61755dcb2dd6a6ce5d9e114400cbd694229f38523e935703cc62f
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version: 7.3.6
+  resolution: "vite@npm:7.3.6"
+  dependencies:
+    esbuild: "npm:^0.27.0 || ^0.28.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10/6fcbadb1a409990e1bbd4ff0ff41e763c87049228cdc407984bdca40b96ab32de0f1f70fa62fb1f3ca001a5b90accbbe22ddfad5cc436855058357b3f2141d3b
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^3.2.4":
+  version: 3.2.7
+  resolution: "vitest@npm:3.2.7"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/expect": "npm:3.2.7"
+    "@vitest/mocker": "npm:3.2.7"
+    "@vitest/pretty-format": "npm:^3.2.7"
+    "@vitest/runner": "npm:3.2.7"
+    "@vitest/snapshot": "npm:3.2.7"
+    "@vitest/spy": "npm:3.2.7"
+    "@vitest/utils": "npm:3.2.7"
+    chai: "npm:^5.2.0"
+    debug: "npm:^4.4.1"
+    expect-type: "npm:^1.2.1"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.2"
+    std-env: "npm:^3.9.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.14"
+    tinypool: "npm:^1.1.1"
+    tinyrainbow: "npm:^2.0.0"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node: "npm:3.2.4"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/debug": ^4.1.12
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@vitest/browser": 3.2.7
+    "@vitest/ui": 3.2.7
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/debug":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: ./vitest.mjs
+  checksum: 10/b54cba8bbb78450dcc78f84df08417ee6daf86450836cd3e5770e7f375596f7b2f756f587b712ebdf28b41c7768747ae3854407372cd95fe6dbaa8410647b273
+  languageName: node
+  linkType: hard
+
 "wagmi@npm:>=3.6, wagmi@npm:^3.6.21":
   version: 3.6.21
   resolution: "wagmi@npm:3.6.21"
@@ -19882,6 +20638,13 @@ __metadata:
   bin:
     webpack-bundle-analyzer: lib/bin/analyzer.js
   checksum: 10/bc7bc2c014ba36dfb3f28ef75e3bb4be17ebff092ae713a30392a1d578a73b5d83ed0940b9d12eca6b06e514218d8a1e7cb0610f0b4d74b53425be3f0cc3aea8
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "whatwg-mimetype@npm:3.0.0"
+  checksum: 10/96f9f628c663c2ae05412c185ca81b3df54bcb921ab52fe9ebc0081c1720f25d770665401eb2338ab7f48c71568133845638e18a81ed52ab5d4dcef7d22b40ef
   languageName: node
   linkType: hard
 
@@ -20033,6 +20796,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10/dbea77c7d3058bf6c78bf9659d2dce4d2b57d39a15b826b2af6ac2e5a219b99dc8a831b79fdbc453c0598adb4f3f84cf9c2491fd52beb9f5d2dececcad117f68
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10/0de6e6cd8f2f94a8b5ca44e84cf1751eadcac3ebedcdc6e5fbbe6c8011904afcbc1a2777c53496ec02ced7b81f2e7eda61e76bf8262a8bc3ceaa1f6040508051
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Bugs found & fixed by the new unit test suite

### 1. Ledger Live: `TypeError` when the host reports zero accounts
**Symptom:** When Ledger Live emits `accountsChanged` with an empty list (user revokes
account access), the connector threw `TypeError: this.disconnect is not a function`
after emitting `disconnect`, leaving stale event listeners attached.
**Root cause:** `onAccountsChanged` was registered directly as an eventemitter3
listener, and eventemitter3 invokes listeners with the *emitter* (the provider) as
`this` — so `this.disconnect()` resolved against the provider, not the connector.
The old "works without bind" comment was only true for the closure-captured `emitter`.
**Fix:** event handling moved to standalone closures (`handlers` in
`src/iframe/connector.ts`) that never rely on `this`; `detach()` removes the
listeners from every created provider.
**Test:** `iframe/__tests__/connector.test.ts` — "disconnects and detaches when the
host reports no accounts".

### 2. Ledger Live: duplicate listeners stack on every reconnect
**Symptom:** After `connect()` runs more than once on a live connector (wagmi does
this on reconnect flows), every host event was forwarded to wagmi once *per connect* —
duplicate `change`/`disconnect` events, growing with each reconnect.
**Root cause:** eventemitter3 registers duplicate listeners; `connect()` attached the
handlers unconditionally and nothing removed the previous registration.
**Fix:** `connect()` now calls `handlers.detach()` before attaching, making it
idempotent. (Pre-existing bug — the old `this`-based code had the same pattern.)
**Test:** "does not stack listeners across repeated connects".

### 3. SSR crash in `clearLedgerDerivationPath`
**Symptom:** Calling `clearLedgerDerivationPath()` in a server-side context (Next.js
SSR) threw `ReferenceError: window is not defined`.
**Root cause:** the guard used `window?.localStorage` — optional chaining protects
against `window` being `undefined`, but not against the identifier being *undeclared*,
which is the SSR reality.
**Fix:** switched to the `typeof window === 'undefined'` guard used by the sibling
helpers (`src/hid/helpers.ts`).
**Test:** `src/__tests__/ssr.test.ts` runs all persistence helpers in a node
(windowless) environment.